### PR TITLE
Update return-dispatch version and clarify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ An example using both of these actions is documented below.
 
 ## Usage
 
-Once you have configured your remote repository to work as expected with the `return-dispatch` action, include `await-remote-run` as described below.
+Once you have configured your remote repository to work as expected with the `return-dispatch` action (**including accepting and echoing back the distinct_id input in your target workflow**), include `await-remote-run` as described below.
 
 ```yaml
 steps:
   - name: Dispatch an action and get the run ID
-    uses: codex-/return-dispatch@v1
+    uses: codex-/return-dispatch@v2
     id: return_dispatch
     with:
       token: ${{ github.token }}


### PR DESCRIPTION
As described in [Codex-/return-dispatch#292](https://github.com/Codex-/return-dispatch/issues/292), I had trouble when half-heartedly following the instructions in this action, assuming it would be just as setup-less and self-contained as any other normal action. Since modification to my own workflows are needed, I tried to make this more clear.