### PR TITLE
Implement etag handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@eslint/compat": "^1.2.9",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.28.0",
+    "@octokit/types": "^14.1.0",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^20.17.57",
     "@typescript-eslint/eslint-plugin": "^8.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^9.28.0
         version: 9.28.0
+      '@octokit/types':
+        specifier: ^14.1.0
+        version: 14.1.0
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -435,6 +438,9 @@ packages:
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
   '@octokit/plugin-paginate-rest@9.2.2':
     resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
     engines: {node: '>= 18'}
@@ -460,6 +466,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2863,6 +2872,8 @@ snapshots:
 
   '@octokit/openapi-types@24.2.0': {}
 
+  '@octokit/openapi-types@25.1.0': {}
+
   '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.1)':
     dependencies:
       '@octokit/core': 5.2.1
@@ -2893,6 +2904,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -18,7 +18,7 @@ import {
   init,
   retryOnError,
 } from "./api.ts";
-import { clearEtags } from "./etags.js";
+import { clearEtags } from "./etags.ts";
 
 vi.mock("@actions/core");
 vi.mock("@actions/github");

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -18,6 +18,7 @@ import {
   init,
   retryOnError,
 } from "./api.ts";
+import { clearEtags } from "./etags.js";
 
 vi.mock("@actions/core");
 vi.mock("@actions/github");
@@ -25,6 +26,7 @@ vi.mock("@actions/github");
 interface MockResponse {
   data: any;
   status: number;
+  headers: Record<string, string>;
 }
 
 const mockOctokit = {
@@ -39,6 +41,10 @@ const mockOctokit = {
     },
   },
 };
+
+afterEach(() => {
+  clearEtags();
+});
 
 describe("API", () => {
   const cfg = {
@@ -72,6 +78,7 @@ describe("API", () => {
         Promise.resolve({
           data: mockData,
           status: 200,
+          headers: {},
         }),
       );
 
@@ -86,12 +93,102 @@ describe("API", () => {
         Promise.resolve({
           data: undefined,
           status: errorStatus,
+          headers: {},
         }),
       );
 
       await expect(getWorkflowRunState(0)).rejects.toThrow(
         `Failed to get Workflow Run state, expected 200 but received ${errorStatus}`,
       );
+    });
+
+    it("should send the previous etag in the If-None-Match header", async () => {
+      const mockData = {
+        status: "completed",
+        conclusion: "cancelled",
+      };
+      const etag =
+        "37c2311495bbea359329d0bb72561bdb2b2fffea1b7a54f696b5a287e7ccad1e";
+      let submittedEtag = null;
+      vi.spyOn(mockOctokit.rest.actions, "getWorkflowRun").mockReturnValue(
+        Promise.resolve({
+          data: mockData,
+          status: 200,
+          headers: {},
+        }),
+      );
+      vi.spyOn(mockOctokit.rest.actions, "getWorkflowRun").mockImplementation(
+        ({ headers }) => {
+          if (headers?.["If-None-Match"]) {
+            submittedEtag = headers["If-None-Match"];
+            return Promise.resolve({
+              data: null,
+              status: 304,
+              headers: {
+                etag: `W/"${submittedEtag}"`,
+              },
+            });
+          }
+          return Promise.resolve({
+            data: mockData,
+            status: 200,
+            headers: {
+              etag: `W/"${etag}"`,
+            },
+          });
+        },
+      );
+
+      // Behaviour
+      // First API call will return 200 with an etag response header
+      const state = await getWorkflowRunState(123456);
+      expect(state.conclusion).toStrictEqual("cancelled");
+      expect(state.status).toStrictEqual("completed");
+      // Second API call with same parameters should pass the If-None-Match header
+      const state2 = await getWorkflowRunState(123456);
+      expect(state2.conclusion).toStrictEqual(mockData.conclusion);
+      expect(state2.status).toStrictEqual(mockData.status);
+    });
+
+    it("should not send the previous etag in the If-None-Match header when different request params are used", async () => {
+      const mockData = {
+        status: "completed",
+        conclusion: "cancelled",
+      };
+      const etag =
+        "37c2311495bbea359329d0bb72561bdb2b2fffea1b7a54f696b5a287e7ccad1e";
+      let submittedEtag = null;
+      vi.spyOn(mockOctokit.rest.actions, "getWorkflowRun").mockImplementation(
+        ({ headers }) => {
+          if (headers?.["If-None-Match"]) {
+            submittedEtag = headers["If-None-Match"];
+            return Promise.resolve({
+              data: null,
+              status: 304,
+              headers: {
+                etag: `W/"${submittedEtag}"`,
+              },
+            });
+          }
+          return Promise.resolve({
+            data: mockData,
+            status: 200,
+            headers: {
+              etag: `W/"${etag}"`,
+            },
+          });
+        },
+      );
+
+      // Behaviour
+      // First API call will return 200 with an etag response header
+      const state = await getWorkflowRunState(123456);
+      expect(state.conclusion).toStrictEqual("cancelled");
+      expect(state.status).toStrictEqual("completed");
+      // Second API call, without If-None-Match header because of different parameters
+      const state2 = await getWorkflowRunState(123457);
+      expect(state2.conclusion).toStrictEqual("cancelled");
+      expect(state2.status).toStrictEqual("completed");
     });
   });
 
@@ -132,6 +229,7 @@ describe("API", () => {
           Promise.resolve({
             data: mockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -154,6 +252,7 @@ describe("API", () => {
           Promise.resolve({
             data: undefined,
             status: errorStatus,
+            headers: {},
           }),
         );
 
@@ -171,6 +270,7 @@ describe("API", () => {
           Promise.resolve({
             data: mockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -209,6 +309,7 @@ describe("API", () => {
           Promise.resolve({
             data: inProgressMockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -226,6 +327,7 @@ describe("API", () => {
           Promise.resolve({
             data: inProgressMockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -242,6 +344,7 @@ describe("API", () => {
           Promise.resolve({
             data: undefined,
             status: errorStatus,
+            headers: {},
           }),
         );
 
@@ -260,6 +363,7 @@ describe("API", () => {
           Promise.resolve({
             data: inProgressMockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -277,6 +381,7 @@ describe("API", () => {
           Promise.resolve({
             data: inProgressMockData,
             status: 200,
+            headers: {},
           }),
         );
 
@@ -303,6 +408,7 @@ describe("API", () => {
             Promise.resolve({
               data: inProgressMockData,
               status: 200,
+              headers: {},
             }),
           );
 
@@ -323,6 +429,7 @@ describe("API", () => {
               return Promise.resolve({
                 data: inProgressMockData,
                 status: 200,
+                headers: {},
               });
             })
             // First
@@ -332,6 +439,7 @@ describe("API", () => {
               return Promise.resolve({
                 data: inProgressMockData,
                 status: 200,
+                headers: {},
               });
             })
             // Second
@@ -339,6 +447,7 @@ describe("API", () => {
               Promise.resolve({
                 data: inProgressMockData,
                 status: 200,
+                headers: {},
               }),
             );
 
@@ -358,6 +467,7 @@ describe("API", () => {
             Promise.resolve({
               data: inProgressMockData,
               status: 200,
+              headers: {},
             }),
           );
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 
 import { type ActionConfig, getConfig } from "./action.ts";
-import { withEtag } from "./etags.js";
+import { withEtag } from "./etags.ts";
 
 type Octokit = ReturnType<(typeof github)["getOctokit"]>;
 
@@ -48,7 +48,7 @@ export async function getWorkflowRunState(
       },
       async (params) => {
         // https://docs.github.com/en/rest/reference/actions#get-a-workflow-run
-        return await octokit.rest.actions.getWorkflowRun(params);
+        return octokit.rest.actions.getWorkflowRun(params);
       },
     );
 

--- a/src/etags.ts
+++ b/src/etags.ts
@@ -1,0 +1,68 @@
+import type {
+  RequestHeaders,
+  RequestParameters,
+  OctokitResponse,
+} from "@octokit/types";
+
+interface EtagStoreEntry {
+  etag: string;
+  savedResponse: OctokitResponse<any>;
+}
+
+const etagStore = new Map<string, EtagStoreEntry>();
+
+export async function withEtag<T, P extends RequestParameters>(
+  endpoint: string,
+  params: P,
+  requester: (params: P) => Promise<OctokitResponse<T>>,
+): Promise<OctokitResponse<T>> {
+  const { etag, savedResponse } = getEtag(endpoint, params) ?? {};
+
+  const paramsWithEtag = { ...params };
+  if (etag)
+    paramsWithEtag.headers = {
+      "If-None-Match": etag,
+      ...(params.headers ?? {}),
+    } satisfies RequestHeaders;
+
+  const response = await requester(paramsWithEtag);
+
+  if (
+    response.status === 304 &&
+    etag &&
+    etag === extractEtag(response) &&
+    savedResponse !== undefined
+  ) {
+    return savedResponse;
+  }
+
+  rememberEtag(endpoint, params, response);
+  return response;
+}
+
+function extractEtag(response: OctokitResponse<any>): string | undefined {
+  if ("string" !== typeof response.headers.etag) return;
+  return response.headers.etag.split('"')[1] ?? "";
+}
+
+function getEtag(endpoint: string, params: object): EtagStoreEntry | undefined {
+  return etagStore.get(JSON.stringify({ endpoint, params }));
+}
+
+function rememberEtag(
+  endpoint: string,
+  params: object,
+  response: OctokitResponse<any>,
+): void {
+  const etag = extractEtag(response);
+  if (!etag) return;
+
+  etagStore.set(JSON.stringify({ endpoint, params }), {
+    etag,
+    savedResponse: response,
+  });
+}
+
+export function clearEtags(): void {
+  etagStore.clear();
+}


### PR DESCRIPTION
Fixes [Codex-/return-dispatch#295](https://github.com/Codex-/return-dispatch/issues/295)
See https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate for GitHub's documentation on how to use etags to avoid the API request rate limit.

Same change as [Codex-/return-dispatch#296](https://github.com/Codex-/return-dispatch/issues/296), but for this action.
There is currently only one request which is repeated in a loop in this action.

I am currently testing this update in our repository system with one workflow triggering ~25 other workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added ETag-based caching for API requests to improve efficiency and reduce redundant data fetching.

* **Tests**
  * Enhanced test coverage to verify correct ETag handling and caching behavior in API requests.

* **Chores**
  * Added a new development dependency for improved type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->