### PR TITLE
feat: Implement cancelling runs after a given timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,15 @@ steps:
       owner: codex-
       run_id: ${{ steps.return_dispatch.outputs.run_id }}
       run_timeout_seconds: 300 # Optional
+      cancel_timeout_seconds: 240 # Optional
       poll_interval_ms: 5000 # Optional
 ```
+
+### Cancelling the remote run
+
+Giving up on a remote run leaves it running, which is a problem if your workflow tears down something that run depends on, such as a test environment.
+
+Set `cancel_timeout_seconds` to request cancellation once that much time has elapsed. It must be less than `run_timeout_seconds`, the difference being how long this action keeps polling to observe the resulting `cancelled` conclusion. Cancellation requires `actions:write` and is asynchronous, so the remote run may take some time to wind down.
 
 ### Permissions Required
 
@@ -46,6 +53,8 @@ The permissions required for this action to function correctly are:
   - You may get away with simply having `repo:public_repo`
   - `repo` is definitely needed if the repository is private.
 - `actions:read`
+- `actions:write`
+  - Only required when using `cancel_timeout_seconds`
 
 ### APIs Used
 
@@ -61,6 +70,11 @@ For the sake of transparency please note that this action uses the following API
   - Permissions:
     - `repo`
     - `actions:read`
+- [Cancel a workflow run](https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run), only if using `cancel_timeout_seconds`
+  - POST `/repos/{owner}/{repo}/actions/runs/{run_id}/cancel`
+  - Permissions:
+    - `repo`
+    - `actions:write`
 
 For more information please see [api.ts](./src/api.ts).
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   run_timeout_seconds:
     description: Time until giving up on the run.
     default: 300
+  cancel_timeout_seconds:
+    description: >-
+      Time until requesting cancellation of the remote run, if set.
+      Must be less than run_timeout_seconds.
   poll_interval_ms:
     description: Frequency to poll the run for a status.
     default: 5000

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -20121,12 +20121,22 @@ function info(message) {
 var RUN_TIMEOUT_SECONDS = 5 * 60;
 var POLL_INTERVAL_MS = 5e3;
 function getConfig() {
+  const runTimeoutSeconds = getNumberFromValue(getInput("run_timeout_seconds")) ?? RUN_TIMEOUT_SECONDS;
+  const cancelTimeoutSeconds = getNumberFromValue(
+    getInput("cancel_timeout_seconds")
+  );
+  if (cancelTimeoutSeconds !== void 0 && cancelTimeoutSeconds >= runTimeoutSeconds) {
+    throw new TypeError(
+      `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`
+    );
+  }
   return {
     token: getInput("token", { required: true }),
     repo: getInput("repo", { required: true }),
     owner: getInput("owner", { required: true }),
     runId: getRunIdFromValue(getInput("run_id")),
-    runTimeoutSeconds: getNumberFromValue(getInput("run_timeout_seconds")) ?? RUN_TIMEOUT_SECONDS,
+    runTimeoutSeconds,
+    cancelTimeoutSeconds,
     pollIntervalMs: getNumberFromValue(getInput("poll_interval_ms")) ?? POLL_INTERVAL_MS
   };
 }
@@ -23982,6 +23992,56 @@ async function fetchWorkflowRunState(runId) {
     throw error2;
   }
 }
+function isHttpError(error2) {
+  return error2 instanceof Error && error2.name === "HttpError";
+}
+function isRetryable(error2) {
+  if (error2.status >= 500 || error2.status === 429) {
+    return true;
+  }
+  return error2.status === 403 && isRateLimited(error2);
+}
+function isRateLimited(error2) {
+  const headers = error2.response?.headers;
+  return headers?.["retry-after"] !== void 0 || headers?.["x-ratelimit-remaining"] === "0";
+}
+async function requestWorkflowRunCancel(runId) {
+  try {
+    const response = await octokit.rest.actions.cancelWorkflowRun({
+      owner: config.owner,
+      repo: config.repo,
+      run_id: runId
+    });
+    if (response.status !== 202) {
+      throw new Error(
+        `Failed to request Workflow Run cancellation, expected 202 but received ${response.status}`
+      );
+    }
+    debug(`Requested cancellation of Workflow Run ${runId}`);
+    return { success: true };
+  } catch (error2) {
+    if (isHttpError(error2) && !isRetryable(error2)) {
+      if (error2.status === 409) {
+        info(
+          `Workflow Run ${runId} is not in a cancellable state, continuing...`
+        );
+      } else {
+        warning(
+          `Cancellation of Workflow Run ${runId} was rejected with ${error2.status}, not retrying`
+        );
+      }
+      return { success: false, reason: "rejected" };
+    }
+    warning(
+      `requestWorkflowRunCancel: An unexpected error has occurred:
+  error: ${error2 instanceof Error ? error2.message : String(error2)}`
+    );
+    if (error2 instanceof Error) {
+      debug(error2.stack ?? "");
+    }
+    return { success: false, reason: "failed" };
+  }
+}
 async function fetchWorkflowRunJobs(runId) {
   const response = await octokit.rest.actions.listJobsForWorkflowRun({
     owner: config.owner,
@@ -24206,11 +24266,12 @@ async function getWorkflowRunResult({
   startTime,
   runId,
   runTimeoutMs,
-  pollIntervalMs
+  pollIntervalMs,
+  cancelTimeoutMs
 }) {
   let attemptNo = 0;
-  let elapsedTime = Date.now() - startTime;
-  while (elapsedTime < runTimeoutMs) {
+  let cancelRequested = false;
+  while (Date.now() - startTime < runTimeoutMs) {
     attemptNo++;
     const fetchWorkflowRunStateResult = await retryOnError(
       async () => fetchWorkflowRunState(runId),
@@ -24249,8 +24310,15 @@ async function getWorkflowRunResult({
     } else {
       debug(`Failed to fetch run state, attempt ${attemptNo}...`);
     }
+    const elapsedTime = Date.now() - startTime;
+    if (cancelTimeoutMs !== void 0 && !cancelRequested && elapsedTime >= cancelTimeoutMs) {
+      warning(
+        `Cancel timeout exceeded (${elapsedTime}ms), requesting cancellation of Workflow Run ${runId}`
+      );
+      const cancelResult = await requestWorkflowRunCancel(runId);
+      cancelRequested = cancelResult.success || cancelResult.reason === "rejected";
+    }
     await sleep(pollIntervalMs);
-    elapsedTime = Date.now() - startTime;
   }
   return {
     success: false,
@@ -24283,7 +24351,8 @@ async function main() {
       startTime,
       pollIntervalMs: config2.pollIntervalMs,
       runId: config2.runId,
-      runTimeoutMs: config2.runTimeoutSeconds * 1e3
+      runTimeoutMs: config2.runTimeoutSeconds * 1e3,
+      cancelTimeoutMs: config2.cancelTimeoutSeconds === void 0 ? void 0 : config2.cancelTimeoutSeconds * 1e3
     });
     if (!runResult.success) {
       const elapsedTime = Date.now() - startTime;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -20125,10 +20125,17 @@ function getConfig() {
   const cancelTimeoutSeconds = getNumberFromValue(
     getInput("cancel_timeout_seconds")
   );
-  if (cancelTimeoutSeconds !== void 0 && cancelTimeoutSeconds >= runTimeoutSeconds) {
-    throw new TypeError(
-      `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`
-    );
+  if (cancelTimeoutSeconds !== void 0) {
+    if (cancelTimeoutSeconds <= 0) {
+      throw new TypeError(
+        `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be a positive number.`
+      );
+    }
+    if (cancelTimeoutSeconds >= runTimeoutSeconds) {
+      throw new TypeError(
+        `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`
+      );
+    }
   }
   return {
     token: getInput("token", { required: true }),
@@ -23993,7 +24000,7 @@ async function fetchWorkflowRunState(runId) {
   }
 }
 function isHttpError(error2) {
-  return error2 instanceof Error && error2.name === "HttpError";
+  return error2 instanceof Error && error2.name === "HttpError" && "status" in error2 && typeof error2.status === "number";
 }
 function isRetryable(error2) {
   if (error2.status >= 500 || error2.status === 429) {

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -80,6 +80,21 @@ describe("Action", () => {
       assertNoneCalled();
     });
 
+    it.each(["0", "-1"])(
+      "should throw if cancel_timeout_seconds (%s) is not positive",
+      (cancelTimeoutSeconds) => {
+        mockEnvConfig.cancel_timeout_seconds = cancelTimeoutSeconds;
+
+        // Behaviour
+        expect(() => getConfig()).toThrow(
+          `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be a positive number.`,
+        );
+
+        // Logging
+        assertNoneCalled();
+      },
+    );
+
     it.each(["300", "301"])(
       "should throw if cancel_timeout_seconds (%s) is not less than run_timeout_seconds",
       (cancelTimeoutSeconds) => {

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -20,6 +20,7 @@ describe("Action", () => {
         owner: "owner",
         run_id: "123456",
         run_timeout_seconds: "300",
+        cancel_timeout_seconds: "",
         poll_interval_ms: "2500",
       };
 
@@ -36,6 +37,8 @@ describe("Action", () => {
             return mockEnvConfig.run_id;
           case "run_timeout_seconds":
             return mockEnvConfig.run_timeout_seconds;
+          case "cancel_timeout_seconds":
+            return mockEnvConfig.cancel_timeout_seconds;
           case "poll_interval_ms":
             return mockEnvConfig.poll_interval_ms;
           default:
@@ -59,7 +62,47 @@ describe("Action", () => {
       expect(config.owner).toStrictEqual("owner");
       expect(config.runId).toStrictEqual(123456);
       expect(config.runTimeoutSeconds).toStrictEqual(300);
+      expect(config.cancelTimeoutSeconds).toBeUndefined();
       expect(config.pollIntervalMs).toStrictEqual(2500);
+
+      // Logging
+      assertNoneCalled();
+    });
+
+    it("should return cancel_timeout_seconds if one is supplied", () => {
+      mockEnvConfig.cancel_timeout_seconds = "120";
+
+      // Behaviour
+      const config: ActionConfig = getConfig();
+      expect(config.cancelTimeoutSeconds).toStrictEqual(120);
+
+      // Logging
+      assertNoneCalled();
+    });
+
+    it.each(["300", "301"])(
+      "should throw if cancel_timeout_seconds (%s) is not less than run_timeout_seconds",
+      (cancelTimeoutSeconds) => {
+        mockEnvConfig.cancel_timeout_seconds = cancelTimeoutSeconds;
+
+        // Behaviour
+        expect(() => getConfig()).toThrow(
+          `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (300).`,
+        );
+
+        // Logging
+        assertNoneCalled();
+      },
+    );
+
+    it("should compare cancel_timeout_seconds against the default run_timeout_seconds", () => {
+      mockEnvConfig.run_timeout_seconds = "";
+      mockEnvConfig.cancel_timeout_seconds = "600";
+
+      // Behaviour
+      expect(() => getConfig()).toThrow(
+        "cancel_timeout_seconds (600) must be less than run_timeout_seconds (300).",
+      );
 
       // Logging
       assertNoneCalled();

--- a/src/action.ts
+++ b/src/action.ts
@@ -57,15 +57,20 @@ export function getConfig(): ActionConfig {
     core.getInput("cancel_timeout_seconds"),
   );
 
-  // Cancellation is requested from the polling loop, so a cancel timeout at or
-  // beyond the run timeout would never fire.
-  if (
-    cancelTimeoutSeconds !== undefined &&
-    cancelTimeoutSeconds >= runTimeoutSeconds
-  ) {
-    throw new TypeError(
-      `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`,
-    );
+  if (cancelTimeoutSeconds !== undefined) {
+    if (cancelTimeoutSeconds <= 0) {
+      throw new TypeError(
+        `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be a positive number.`,
+      );
+    }
+
+    // Cancellation is requested from the polling loop, so a cancel timeout at
+    // or beyond the run timeout would never fire.
+    if (cancelTimeoutSeconds >= runTimeoutSeconds) {
+      throw new TypeError(
+        `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`,
+      );
+    }
   }
 
   return {

--- a/src/action.ts
+++ b/src/action.ts
@@ -34,6 +34,15 @@ export interface ActionConfig {
   runTimeoutSeconds: number;
 
   /**
+   * Time until requesting cancellation of the remote run.
+   *
+   * Must be less than `runTimeoutSeconds`.
+   *
+   * @default undefined
+   */
+  cancelTimeoutSeconds?: number;
+
+  /**
    * Frequency to poll the action for a status.
    * @default 2500
    */
@@ -41,14 +50,31 @@ export interface ActionConfig {
 }
 
 export function getConfig(): ActionConfig {
+  const runTimeoutSeconds =
+    getNumberFromValue(core.getInput("run_timeout_seconds")) ??
+    RUN_TIMEOUT_SECONDS;
+  const cancelTimeoutSeconds = getNumberFromValue(
+    core.getInput("cancel_timeout_seconds"),
+  );
+
+  // Cancellation is requested from the polling loop, so a cancel timeout at or
+  // beyond the run timeout would never fire.
+  if (
+    cancelTimeoutSeconds !== undefined &&
+    cancelTimeoutSeconds >= runTimeoutSeconds
+  ) {
+    throw new TypeError(
+      `cancel_timeout_seconds (${cancelTimeoutSeconds}) must be less than run_timeout_seconds (${runTimeoutSeconds}).`,
+    );
+  }
+
   return {
     token: core.getInput("token", { required: true }),
     repo: core.getInput("repo", { required: true }),
     owner: core.getInput("owner", { required: true }),
     runId: getRunIdFromValue(core.getInput("run_id")),
-    runTimeoutSeconds:
-      getNumberFromValue(core.getInput("run_timeout_seconds")) ??
-      RUN_TIMEOUT_SECONDS,
+    runTimeoutSeconds,
+    cancelTimeoutSeconds,
     pollIntervalMs:
       getNumberFromValue(core.getInput("poll_interval_ms")) ?? POLL_INTERVAL_MS,
   };

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -16,6 +16,7 @@ import {
   fetchWorkflowRunFailedJobs,
   fetchWorkflowRunState,
   init,
+  requestWorkflowRunCancel,
   retryOnError,
 } from "./api.ts";
 import * as constants from "./constants.ts";
@@ -40,9 +41,27 @@ const mockOctokit = {
       listJobsForWorkflowRun: (_req?: any): Promise<MockResponse> => {
         throw new Error("Should be mocked");
       },
+      cancelWorkflowRun: (_req?: any): Promise<MockResponse> => {
+        throw new Error("Should be mocked");
+      },
     },
   },
 };
+
+/**
+ * Octokit identifies a failed request by name rather than by class.
+ */
+function mockHttpError(
+  message: string,
+  status: number,
+  headers: Record<string, string | undefined> = {},
+): Error {
+  return Object.assign(new Error(message), {
+    name: "HttpError",
+    status: status,
+    response: { headers: headers },
+  });
+}
 
 afterEach(() => {
   clearEtags();
@@ -56,11 +75,13 @@ describe("API", () => {
     owner: "owner",
     runId: 123456,
     runTimeoutSeconds: 300,
+    cancelTimeoutSeconds: undefined,
     pollIntervalMs: 2500,
   };
 
   const {
     coreErrorLogMock,
+    coreInfoLogMock,
     coreWarningLogMock,
     coreDebugLogMock,
     assertOnlyCalled,
@@ -224,6 +245,177 @@ describe("API", () => {
       const state2 = await fetchWorkflowRunState(123457);
       expect(state2.conclusion).toStrictEqual("cancelled");
       expect(state2.status).toStrictEqual("completed");
+    });
+  });
+
+  describe("requestWorkflowRunCancel", () => {
+    it("should return success if the cancellation is accepted", async () => {
+      const cancelSpy = vi
+        .spyOn(mockOctokit.rest.actions, "cancelWorkflowRun")
+        .mockResolvedValue({ data: undefined, status: 202, headers: {} });
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: true });
+      expect(cancelSpy).toHaveBeenCalledWith({
+        owner: cfg.owner,
+        repo: cfg.repo,
+        run_id: 123456,
+      });
+
+      // Logging
+      assertOnlyCalled(coreDebugLogMock);
+      expect(coreDebugLogMock).toHaveBeenCalledOnce();
+      expect(coreDebugLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+        `"Requested cancellation of Workflow Run 123456"`,
+      );
+    });
+
+    it("should return rejected if the run cannot be cancelled", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        mockHttpError("Conflict", 409),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "rejected" });
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+      expect(coreInfoLogMock).toHaveBeenCalledOnce();
+      expect(coreInfoLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+        `"Workflow Run 123456 is not in a cancellable state, continuing..."`,
+      );
+    });
+
+    // A run cannot become visible or the token gain a scope mid-run, so these
+    // are not worth retrying.
+    it.each([403, 404, 422])(
+      "should return rejected on a %i without retrying",
+      async (status) => {
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "cancelWorkflowRun",
+        ).mockRejectedValue(mockHttpError("Client Error", status));
+
+        // Behaviour
+        const result = await requestWorkflowRunCancel(123456);
+        expect(result).toStrictEqual({ success: false, reason: "rejected" });
+
+        // Logging
+        assertOnlyCalled(coreWarningLogMock);
+        expect(coreWarningLogMock).toHaveBeenCalledOnce();
+        expect(coreWarningLogMock.mock.lastCall?.[0]).toStrictEqual(
+          `Cancellation of Workflow Run 123456 was rejected with ${status}, not retrying`,
+        );
+      },
+    );
+
+    it("should return failed on a rate limit so it is retried", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        mockHttpError("Too Many Requests", 429),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledOnce();
+    });
+
+    // A 403 is a permission problem unless the rate limit headers say
+    // otherwise, in which case retrying can succeed.
+    it.each([{ "x-ratelimit-remaining": "0" }, { "retry-after": "60" }])(
+      "should return failed on a rate limited 403 (%o)",
+      async (headers) => {
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "cancelWorkflowRun",
+        ).mockRejectedValue(mockHttpError("Forbidden", 403, headers));
+
+        // Behaviour
+        const result = await requestWorkflowRunCancel(123456);
+        expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+        // Logging
+        assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+        expect(coreWarningLogMock).toHaveBeenCalledOnce();
+      },
+    );
+
+    it("should return rejected on a 403 with rate limit remaining", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        mockHttpError("Forbidden", 403, { "x-ratelimit-remaining": "4999" }),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "rejected" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock);
+      expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+        `"Cancellation of Workflow Run 123456 was rejected with 403, not retrying"`,
+      );
+    });
+
+    it("should return failed if the request errors", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        mockHttpError("Server Error", 500),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledOnce();
+      expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+        "requestWorkflowRunCancel: An unexpected error has occurred:
+          error: Server Error"
+      `);
+      expect(coreDebugLogMock).toHaveBeenCalledOnce();
+    });
+
+    it("should return failed for a non-request error carrying a status", async () => {
+      // Only a request failure carries a status worth classifying, so anything
+      // else is retried rather than trusted.
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        Object.assign(new Error("Not From Octokit"), { status: 409 }),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledOnce();
+    });
+
+    it("should return failed if a non-202 status is returned", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockResolvedValue(
+        {
+          data: undefined,
+          status: 200,
+          headers: {},
+        },
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledOnce();
+      expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+        "requestWorkflowRunCancel: An unexpected error has occurred:
+          error: Failed to request Workflow Run cancellation, expected 202 but received 200"
+      `);
     });
   });
 

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -396,6 +396,20 @@ describe("API", () => {
       expect(coreWarningLogMock).toHaveBeenCalledOnce();
     });
 
+    it("should return failed for an error named HttpError without a status", async () => {
+      vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockRejectedValue(
+        Object.assign(new Error("Not From Octokit"), { name: "HttpError" }),
+      );
+
+      // Behaviour
+      const result = await requestWorkflowRunCancel(123456);
+      expect(result).toStrictEqual({ success: false, reason: "failed" });
+
+      // Logging
+      assertOnlyCalled(coreWarningLogMock, coreDebugLogMock);
+      expect(coreWarningLogMock).toHaveBeenCalledOnce();
+    });
+
     it("should return failed if a non-202 status is returned", async () => {
       vi.spyOn(mockOctokit.rest.actions, "cancelWorkflowRun").mockResolvedValue(
         {

--- a/src/api.ts
+++ b/src/api.ts
@@ -122,8 +122,8 @@ function isRateLimited(error: HttpError): boolean {
  * Attempt requesting GitHub to cancel a given run.
  *
  * As cancellation is asynchronous: a successful result means GitHub accepted the
- * request, not that the run has stopped. We poll the run state to observe it
- * reaching the `cancelled` conclusion before resolving.
+ * request, not that the run has stopped. The caller's polling is what observes
+ * it reaching the `cancelled` conclusion.
  *
  * Cancellation is best-effort, as a result we don't throw.
  */

--- a/src/api.ts
+++ b/src/api.ts
@@ -89,7 +89,12 @@ function isHttpError(error: unknown): error is HttpError {
   // proto from `@octokit/request-error`. Adding the dependency can
   // cause problematic `instanceof` behaviour if we end up with both
   // the transitive and depended exports being bundled.
-  return error instanceof Error && error.name === "HttpError";
+  return (
+    error instanceof Error &&
+    error.name === "HttpError" &&
+    "status" in error &&
+    typeof error.status === "number"
+  );
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import * as constants from "./constants.ts";
 import { withEtag } from "./etags.ts";
 import type {
   Result,
+  WorkflowRunCancelResult,
   WorkflowRunConclusion,
   WorkflowRunStatus,
 } from "./types.ts";
@@ -69,6 +70,109 @@ export async function fetchWorkflowRunState(
       core.debug(error.stack ?? "");
     }
     throw error;
+  }
+}
+
+/**
+ * Close-enough effort recreation of the error type Octokit throws for any
+ * failed request.
+ *
+ * This also includes ones that never reach GitHub.
+ */
+interface HttpError extends Error {
+  status: number;
+  response?: { headers: Record<string, string | undefined> };
+}
+
+function isHttpError(error: unknown): error is HttpError {
+  // We'll narrow this type based on the name rather than the actual
+  // proto from `@octokit/request-error`. Adding the dependency can
+  // cause problematic `instanceof` behaviour if we end up with both
+  // the transitive and depended exports being bundled.
+  return error instanceof Error && error.name === "HttpError";
+}
+
+/**
+ * Whether a failed request could plausibly succeed if it were tried again.
+ */
+function isRetryable(error: HttpError): boolean {
+  if (error.status >= 500 || error.status === 429) {
+    return true;
+  }
+
+  // A 403 is either a rate limit or a permission problem, and only the former
+  // resolves itself.
+  return error.status === 403 && isRateLimited(error);
+}
+
+/**
+ * Rate limiting is reported as a 403 or a 429, identified by an exhausted
+ * remaining count or by being told when to try again.
+ * See: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#exceeding-the-rate-limit
+ */
+function isRateLimited(error: HttpError): boolean {
+  const headers = error.response?.headers;
+  return (
+    headers?.["retry-after"] !== undefined ||
+    headers?.["x-ratelimit-remaining"] === "0"
+  );
+}
+
+/**
+ * Attempt requesting GitHub to cancel a given run.
+ *
+ * As cancellation is asynchronous: a successful result means GitHub accepted the
+ * request, not that the run has stopped. We poll the run state to observe it
+ * reaching the `cancelled` conclusion before resolving.
+ *
+ * Cancellation is best-effort, as a result we don't throw.
+ */
+export async function requestWorkflowRunCancel(
+  runId: number,
+): Promise<WorkflowRunCancelResult> {
+  try {
+    // https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run
+    const response = await octokit.rest.actions.cancelWorkflowRun({
+      owner: config.owner,
+      repo: config.repo,
+      run_id: runId,
+    });
+
+    // A non-202 is possible, the types aren't the best
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (response.status !== 202) {
+      throw new Error(
+        `Failed to request Workflow Run cancellation, expected 202 but received ${response.status}`,
+      );
+    }
+
+    core.debug(`Requested cancellation of Workflow Run ${runId}`);
+    return { success: true };
+  } catch (error) {
+    if (isHttpError(error) && !isRetryable(error)) {
+      if (error.status === 409) {
+        // The only error the API documents, returned for a run it will not
+        // cancel, such as one that has already concluded.
+        core.info(
+          `Workflow Run ${runId} is not in a cancellable state, continuing...`,
+        );
+      } else {
+        // Most likely a token without `actions:write`, or a run it cannot see.
+        core.warning(
+          `Cancellation of Workflow Run ${runId} was rejected with ${error.status}, not retrying`,
+        );
+      }
+      return { success: false, reason: "rejected" };
+    }
+
+    core.warning(
+      "requestWorkflowRunCancel: An unexpected error has occurred:\n" +
+        `  error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    if (error instanceof Error) {
+      core.debug(error.stack ?? "");
+    }
+    return { success: false, reason: "failed" };
   }
 }
 

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -769,6 +769,32 @@ describe("await-remote-run", () => {
         expect(coreWarningLogMock).toHaveBeenCalledTimes(2);
       });
 
+      it("requests cancellation even while the run state cannot be fetched", async () => {
+        apiRetryOnErrorMock.mockResolvedValue({
+          success: false,
+          reason: "timeout",
+        });
+        apiRequestWorkflowRunCancelMock.mockResolvedValue({ success: true });
+
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: cancelTimeoutMs,
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+
+        expect(result).toStrictEqual({ success: false, reason: "timeout" });
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledOnce();
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock, coreWarningLogMock);
+        expect(coreWarningLogMock).toHaveBeenCalledOnce();
+      });
+
       it("does not request cancellation if the run concludes first", async () => {
         apiFetchWorkflowRunStateMock.mockResolvedValue({
           status: WorkflowRunStatus.Completed,

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -406,12 +406,19 @@ describe("await-remote-run", () => {
       typeof api.fetchWorkflowRunState
     >;
     let apiRetryOnErrorMock: MockInstance<typeof api.retryOnError>;
+    let apiRequestWorkflowRunCancelMock: MockInstance<
+      typeof api.requestWorkflowRunCancel
+    >;
 
     beforeEach(() => {
       vi.useFakeTimers();
 
       apiFetchWorkflowRunStateMock = vi.spyOn(api, "fetchWorkflowRunState");
       apiRetryOnErrorMock = vi.spyOn(api, "retryOnError");
+      apiRequestWorkflowRunCancelMock = vi.spyOn(
+        api,
+        "requestWorkflowRunCancel",
+      );
     });
 
     afterEach(() => {
@@ -627,6 +634,170 @@ describe("await-remote-run", () => {
       expect(coreErrorLogMock.mock.calls).toMatchSnapshot();
       expect(coreInfoLogMock).toHaveBeenCalledOnce();
       expect(coreInfoLogMock.mock.calls).toMatchSnapshot();
+    });
+
+    describe("cancellation", () => {
+      const pollIntervalMs = 100;
+      const runTimeoutMs = 1000;
+      const cancelTimeoutMs = 300;
+
+      beforeEach(() => {
+        apiFetchWorkflowRunStateMock.mockResolvedValue({
+          status: WorkflowRunStatus.InProgress,
+          conclusion: null,
+        });
+        apiRetryOnErrorMock.mockImplementation(async (toTry) => ({
+          success: true,
+          value: await toTry(),
+        }));
+      });
+
+      it("requests cancellation once the cancel timeout elapses", async () => {
+        apiRequestWorkflowRunCancelMock.mockImplementation(() => {
+          // Mirror the remote run reacting to the cancellation, so the
+          // subsequent poll observes the conclusion.
+          apiFetchWorkflowRunStateMock.mockResolvedValue({
+            status: WorkflowRunStatus.Completed,
+            conclusion: WorkflowRunConclusion.Cancelled,
+          });
+          return Promise.resolve({ success: true });
+        });
+
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: cancelTimeoutMs,
+        });
+
+        // Cancellation is requested on the first poll at or after the cancel
+        // timeout, so it should not have fired one interval earlier.
+        await vi.advanceTimersByTimeAsync(cancelTimeoutMs - pollIntervalMs);
+        expect(apiRequestWorkflowRunCancelMock).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+        expect(result).toStrictEqual({
+          success: true,
+          value: {
+            status: WorkflowRunStatus.Completed,
+            conclusion: WorkflowRunConclusion.Cancelled,
+          },
+        });
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledOnce();
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledWith(0);
+
+        // Logging
+        assertOnlyCalled(
+          coreDebugLogMock,
+          coreWarningLogMock,
+          coreErrorLogMock,
+        );
+        expect(coreWarningLogMock).toHaveBeenCalledOnce();
+        expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+          `"Cancel timeout exceeded (300ms), requesting cancellation of Workflow Run 0"`,
+        );
+      });
+
+      it("does not request cancellation if no cancel timeout is given", async () => {
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+
+        expect(result).toStrictEqual({ success: false, reason: "timeout" });
+        expect(apiRequestWorkflowRunCancelMock).not.toHaveBeenCalled();
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+      });
+
+      it("does not retry a rejected cancellation", async () => {
+        apiRequestWorkflowRunCancelMock.mockResolvedValue({
+          success: false,
+          reason: "rejected",
+        });
+
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: cancelTimeoutMs,
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+
+        expect(result).toStrictEqual({ success: false, reason: "timeout" });
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledOnce();
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock, coreWarningLogMock);
+        expect(coreWarningLogMock).toHaveBeenCalledOnce();
+      });
+
+      it("retries a failed cancellation on the next poll", async () => {
+        apiRequestWorkflowRunCancelMock
+          .mockResolvedValue({ success: true })
+          .mockResolvedValueOnce({ success: false, reason: "failed" });
+
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: cancelTimeoutMs,
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+
+        expect(result).toStrictEqual({ success: false, reason: "timeout" });
+        // The failed request is retried, the successful one is not.
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledTimes(2);
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock, coreWarningLogMock);
+        expect(coreWarningLogMock).toHaveBeenCalledTimes(2);
+      });
+
+      it("does not request cancellation if the run concludes first", async () => {
+        apiFetchWorkflowRunStateMock.mockResolvedValue({
+          status: WorkflowRunStatus.Completed,
+          conclusion: WorkflowRunConclusion.Success,
+        });
+
+        // Behaviour
+        const getWorkflowRunResultPromise = getWorkflowRunResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: cancelTimeoutMs,
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+        const result = await getWorkflowRunResultPromise;
+
+        expect(result).toStrictEqual({
+          success: true,
+          value: {
+            status: WorkflowRunStatus.Completed,
+            conclusion: WorkflowRunConclusion.Success,
+          },
+        });
+        expect(apiRequestWorkflowRunCancelMock).not.toHaveBeenCalled();
+
+        // Logging
+        assertNoneCalled();
+      });
     });
 
     it("returns a timeout", async () => {

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -3,6 +3,7 @@ import * as core from "@actions/core";
 import {
   fetchWorkflowRunFailedJobs,
   fetchWorkflowRunState,
+  requestWorkflowRunCancel,
   retryOnError,
 } from "./api.ts";
 import {
@@ -115,12 +116,14 @@ interface RunOpts {
   pollIntervalMs: number;
   runId: number;
   runTimeoutMs: number;
+  cancelTimeoutMs?: number;
 }
 export async function getWorkflowRunResult({
   startTime,
   runId,
   runTimeoutMs,
   pollIntervalMs,
+  cancelTimeoutMs,
 }: RunOpts): Promise<
   Result<
     | { status: WorkflowRunStatus.Completed; conclusion: WorkflowRunConclusion }
@@ -128,8 +131,8 @@ export async function getWorkflowRunResult({
   >
 > {
   let attemptNo = 0;
-  let elapsedTime = Date.now() - startTime;
-  while (elapsedTime < runTimeoutMs) {
+  let cancelRequested = false;
+  while (Date.now() - startTime < runTimeoutMs) {
     attemptNo++;
 
     const fetchWorkflowRunStateResult = await retryOnError(
@@ -179,8 +182,23 @@ export async function getWorkflowRunResult({
       core.debug(`Failed to fetch run state, attempt ${attemptNo}...`);
     }
 
+    const elapsedTime = Date.now() - startTime;
+    if (
+      cancelTimeoutMs !== undefined &&
+      !cancelRequested &&
+      elapsedTime >= cancelTimeoutMs
+    ) {
+      core.warning(
+        `Cancel timeout exceeded (${elapsedTime}ms), requesting cancellation of Workflow Run ${runId}`,
+      );
+      const cancelResult = await requestWorkflowRunCancel(runId);
+      // A failed request may be transient, so leave the request outstanding for
+      // the next poll to retry within the remaining run timeout.
+      cancelRequested =
+        cancelResult.success || cancelResult.reason === "rejected";
+    }
+
     await sleep(pollIntervalMs);
-    elapsedTime = Date.now() - startTime;
   }
 
   return {

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -37,6 +37,7 @@ describe("main", () => {
     owner: "owner",
     runId: 123456,
     runTimeoutSeconds: 300,
+    cancelTimeoutSeconds: undefined,
     pollIntervalMs: 2500,
   };
 
@@ -129,6 +130,7 @@ describe("main", () => {
       pollIntervalMs: testCfg.pollIntervalMs,
       runId: testCfg.runId,
       runTimeoutMs: testCfg.runTimeoutSeconds * 1000,
+      cancelTimeoutMs: undefined,
     });
 
     // Result
@@ -149,6 +151,39 @@ describe("main", () => {
         Status: completed
         Conclusion: success"
     `);
+  });
+
+  it("should pass the cancel timeout through when configured", async () => {
+    actionGetConfigMock.mockReturnValue({
+      ...testCfg,
+      cancelTimeoutSeconds: 120,
+    });
+    apiFetchWorkflowRunActiveJobUrlRetry.mockResolvedValue({
+      success: true,
+      value: "test-url",
+    });
+    awaitRemoteRunGetWorkflowRunResult.mockResolvedValue({
+      success: true,
+      value: {
+        status: WorkflowRunStatus.Completed,
+        conclusion: WorkflowRunConclusion.Success,
+      },
+    });
+
+    await main();
+
+    // Behaviour
+    expect(awaitRemoteRunGetWorkflowRunResult).toHaveBeenCalledOnce();
+    expect(awaitRemoteRunGetWorkflowRunResult).toHaveBeenCalledWith({
+      startTime: Date.now(),
+      pollIntervalMs: testCfg.pollIntervalMs,
+      runId: testCfg.runId,
+      runTimeoutMs: testCfg.runTimeoutSeconds * 1000,
+      cancelTimeoutMs: 120_000,
+    });
+
+    // Logging
+    assertOnlyCalled(coreInfoLogMock);
   });
 
   it("should warn and continue if the active job URL fetch times out", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,10 @@ export async function main(): Promise<void> {
       pollIntervalMs: config.pollIntervalMs,
       runId: config.runId,
       runTimeoutMs: config.runTimeoutSeconds * 1000,
+      cancelTimeoutMs:
+        config.cancelTimeoutSeconds === undefined
+          ? undefined
+          : config.cancelTimeoutSeconds * 1000,
     });
     if (!runResult.success) {
       const elapsedTime = Date.now() - startTime;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,13 @@ interface ResultStatusPending {
   value: WorkflowRunStatus;
 }
 
+/**
+ * Rejected requests will continue to be rejected.
+ * Failed requests can be retried and eventually succeed.
+ */
+export type WorkflowRunCancelResult =
+  { success: true } | { success: false; reason: "rejected" | "failed" };
+
 export type WorkflowRunConclusionResult =
   | ResultSuccess<WorkflowRunConclusion>
   | ResultConclusionInconclusive


### PR DESCRIPTION
Resolves #215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workflow cancellation after a configurable timeout.
  * Cancellation requests are retried when appropriate, while rejected requests allow the action to continue toward timeout.
  * Added validation requiring the cancellation timeout to be shorter than the overall run timeout.
  * Documented the required permission and cancellation API usage.

* **Tests**
  * Added coverage for cancellation, retries, rejection handling, timeout behavior, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->