### PR TITLE
feat: Supporting awaiting a specific job

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,46 @@ steps:
       poll_interval_ms: 5000 # Optional
 ```
 
+### Awaiting specific jobs
+
+Set `jobs` to await named jobs within the run rather than the run itself, one name per
+line. This suits a remote run whose later jobs you don't need to gate on, such as
+awaiting `build` while its `deploy` continues.
+
+```yaml
+- name: Await the remote build
+  uses: Codex-/await-remote-run@v2
+  with:
+    token: ${{ github.token }}
+    repo: repository-name
+    owner: repository-owner
+    run_id: ${{ steps.return_dispatch.outputs.run_id }}
+    jobs: |
+      build
+```
+
+The action resolves once every listed job has concluded with `success`, leaving the rest
+of the run in flight. Any other conclusion, `skipped` included, fails the action
+immediately without awaiting the remaining jobs. `cancel_timeout_seconds` still applies
+to the timeout, but a run whose awaited jobs concluded is never cancelled.
+
+#### Matching job names
+
+Names must match the name GitHub reports, which is not always the workflow's job key:
+
+| Remote workflow                      | Name to use                 |
+| ------------------------------------ | --------------------------- |
+| `build:` with a `name:` set          | the `name:` value           |
+| `build:` using `strategy.matrix`     | `build (ubuntu-latest, 20)` |
+| `build:` calling a reusable workflow | `build / inner-job-name`    |
+
+The list is split on newlines only, as a matrix job carries commas in its name.
+
+Jobs appear as they become eligible, so one still blocked on `needs` is absent rather
+than pending. The action keeps awaiting a name it cannot yet see, failing only once the
+run concludes without it. That failure lists every job the run did produce, which is the
+quickest way to spot a name that never matched.
+
 ### Cancelling the remote run
 
 Giving up on a remote run leaves it running, which is a problem if your workflow tears down something that run depends on, such as a test environment.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ awaiting `build` while its `deploy` continues.
 
 The action resolves once every listed job has concluded with `success`, leaving the rest
 of the run in flight. Any other conclusion, `skipped` included, fails the action
-immediately without awaiting the remaining jobs. `cancel_timeout_seconds` still applies
-to the timeout, but a run whose awaited jobs concluded is never cancelled.
+immediately without awaiting the remaining jobs. With `cancel_timeout_seconds` set, this
+failure also requests cancellation of the run, which can no longer succeed. A run whose
+awaited jobs all succeeded is never cancelled.
 
 #### Matching job names
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
   run_id:
     description: Run ID to await the completion of.
     required: true
+  jobs:
+    description: >-
+      Newline separated names of jobs within the run to await, instead of the
+      whole run. Names must match the job name GitHub reports, which includes
+      matrix parameters.
   run_timeout_seconds:
     description: Time until giving up on the run.
     default: 300

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -20144,8 +20144,15 @@ function getConfig() {
     runId: getRunIdFromValue(getInput("run_id")),
     runTimeoutSeconds,
     cancelTimeoutSeconds,
-    pollIntervalMs: getNumberFromValue(getInput("poll_interval_ms")) ?? POLL_INTERVAL_MS
+    pollIntervalMs: getNumberFromValue(getInput("poll_interval_ms")) ?? POLL_INTERVAL_MS,
+    jobs: getJobsFromValue(getInput("jobs"))
   };
+}
+function getJobsFromValue(value) {
+  const jobs = new Set(
+    value.split("\n").map((job) => job.trim()).filter((job) => job !== "")
+  );
+  return jobs.size > 0 ? [...jobs] : void 0;
 }
 function getRunIdFromValue(value) {
   const id = getNumberFromValue(value);
@@ -23915,6 +23922,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 var WORKFLOW_RUN_ACTIVE_JOB_TIMEOUT_MS = 3e4;
 var WORKFLOW_RUN_ACTIVE_JOB_POLL_INTERVAL_MS = 1e3;
 var ETAG_CACHE_MAX_ENTRIES = 16;
+var JOBS_PER_PAGE = 100;
 
 // src/etag/cache.ts
 var store = /* @__PURE__ */ new Map();
@@ -24108,27 +24116,31 @@ async function requestWorkflowRunCancel(runId) {
   }
 }
 async function fetchWorkflowRunJobs(runId) {
+  return octokit.paginate(octokit.rest.actions.listJobsForWorkflowRun, {
+    owner: config.owner,
+    repo: config.repo,
+    run_id: runId,
+    filter: "latest",
+    per_page: JOBS_PER_PAGE
+  });
+}
+async function fetchWorkflowRunJobsFirstPage(runId) {
   const response = await octokit.rest.actions.listJobsForWorkflowRun({
     owner: config.owner,
     repo: config.repo,
     run_id: runId,
-    filter: "latest"
+    filter: "latest",
+    per_page: JOBS_PER_PAGE
   });
-  if (response.status !== 200) {
-    throw new Error(
-      `Failed to fetch Jobs for Workflow Run, expected 200 but received ${response.status}`
-    );
-  }
-  return response;
+  return response.data.jobs;
 }
 async function fetchWorkflowRunFailedJobs(runId) {
   try {
-    const response = await fetchWorkflowRunJobs(runId);
-    const fetchedFailedJobs = response.data.jobs.filter(
-      (job) => job.conclusion === "failure"
+    const fetchedFailedJobs = (await fetchWorkflowRunJobs(runId)).filter(
+      (job) => job.status === "completed" && job.conclusion !== "success" && job.conclusion !== "skipped"
     );
     if (fetchedFailedJobs.length <= 0) {
-      warning(`Failed to find failed Jobs for Workflow Run ${runId}`);
+      info(`Found no unsuccessful Jobs for Workflow Run ${runId}`);
       return [];
     }
     const jobs = fetchedFailedJobs.map((job) => {
@@ -24175,10 +24187,36 @@ async function fetchWorkflowRunFailedJobs(runId) {
     throw error2;
   }
 }
+async function fetchWorkflowRunJobStates(runId) {
+  try {
+    const jobs = (await fetchWorkflowRunJobs(runId)).map((job) => ({
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion
+    }));
+    const jobStates = jobs.map(
+      (job) => `${job.name} (${job.status}, ${job.conclusion})`
+    );
+    debug(
+      `Fetched Job states for Run:
+  Repository: ${config.owner}/${config.repo}
+  Run ID: ${runId}
+  Jobs: [${jobStates.join(", ")}]`
+    );
+    return jobs;
+  } catch (error2) {
+    if (error2 instanceof Error) {
+      error(
+        `fetchWorkflowRunJobStates: An unexpected error has occurred: ${error2.message}`
+      );
+      debug(error2.stack ?? "");
+    }
+    throw error2;
+  }
+}
 async function fetchWorkflowRunActiveJobUrl(runId) {
   try {
-    const response = await fetchWorkflowRunJobs(runId);
-    const fetchedInProgressJobs = response.data.jobs.filter(
+    const fetchedInProgressJobs = (await fetchWorkflowRunJobsFirstPage(runId)).filter(
       (job) => job.status === "in_progress" || job.status === "completed"
     );
     const inProgressJobs = fetchedInProgressJobs.map(
@@ -24248,6 +24286,9 @@ async function retryOnError(func, timeoutMs, functionName) {
     reason: "timeout"
   };
 }
+
+// src/types.ts
+var POLL_PENDING = { done: false };
 
 // src/await-remote-run.ts
 function getWorkflowRunStatusResult(status, attemptNo) {
@@ -24330,58 +24371,47 @@ async function handleActionFail(failureMsg, runId) {
 function getWorkflowRunStateResult(status, conclusion, attemptNo) {
   const statusResult = getWorkflowRunStatusResult(status, attemptNo);
   if (!statusResult.success) {
-    return statusResult.reason === "unsupported" ? statusResult : void 0;
+    return statusResult.reason === "unsupported" ? { done: true, value: statusResult } : POLL_PENDING;
   }
   const conclusionResult = getWorkflowRunConclusionResult(conclusion);
   if (conclusionResult.success || conclusionResult.reason === "inconclusive") {
     return {
-      success: true,
+      done: true,
       value: {
-        status: statusResult.value,
-        conclusion: conclusionResult.value
+        success: true,
+        value: {
+          status: statusResult.value,
+          conclusion: conclusionResult.value
+        }
       }
     };
   }
   if (conclusionResult.reason === "timed_out") {
     return {
-      success: false,
-      reason: "timeout"
+      done: true,
+      value: {
+        success: false,
+        reason: "timeout"
+      }
     };
   }
   return {
-    success: false,
-    reason: "unsupported",
-    value: conclusionResult.value
+    done: true,
+    value: {
+      success: false,
+      reason: "unsupported",
+      value: conclusionResult.value
+    }
   };
 }
-async function getWorkflowRunResult({
-  startTime,
-  runId,
-  runTimeoutMs,
-  pollIntervalMs,
-  cancelTimeoutMs
-}) {
+async function pollRun({ startTime, runId, runTimeoutMs, pollIntervalMs, cancelTimeoutMs }, attempt) {
   let attemptNo = 0;
   let cancelRequested = false;
   while (Date.now() - startTime < runTimeoutMs) {
     attemptNo++;
-    const fetchWorkflowRunStateResult = await retryOnError(
-      async () => fetchWorkflowRunState(runId),
-      400,
-      "fetchWorkflowRunState"
-    );
-    if (fetchWorkflowRunStateResult.success) {
-      const { status, conclusion } = fetchWorkflowRunStateResult.value;
-      const stateResult = getWorkflowRunStateResult(
-        status,
-        conclusion,
-        attemptNo
-      );
-      if (stateResult !== void 0) {
-        return stateResult;
-      }
-    } else {
-      debug(`Failed to fetch run state, attempt ${attemptNo}...`);
+    const attempted = await attempt(attemptNo);
+    if (attempted.done) {
+      return attempted.value;
     }
     const elapsedTime = Date.now() - startTime;
     if (cancelTimeoutMs !== void 0 && !cancelRequested && elapsedTime >= cancelTimeoutMs) {
@@ -24398,8 +24428,131 @@ async function getWorkflowRunResult({
     reason: "timeout"
   };
 }
+async function getWorkflowRunResult(opts) {
+  return pollRun(opts, async (attemptNo) => {
+    const fetchWorkflowRunStateResult = await retryOnError(
+      async () => fetchWorkflowRunState(opts.runId),
+      400,
+      "fetchWorkflowRunState"
+    );
+    if (!fetchWorkflowRunStateResult.success) {
+      debug(`Failed to fetch run state, attempt ${attemptNo}...`);
+      return POLL_PENDING;
+    }
+    const { status, conclusion } = fetchWorkflowRunStateResult.value;
+    return getWorkflowRunStateResult(status, conclusion, attemptNo);
+  });
+}
+function getWorkflowRunJobsStateResult(awaited, jobs, runCompleted) {
+  const byName = Map.groupBy(jobs, (job) => job.name);
+  const concluded = [];
+  const inconclusive = [];
+  const missing = [];
+  for (const name of awaited) {
+    const named = byName.get(name) ?? [];
+    const failed = named.filter(
+      (job) => job.status === "completed" && job.conclusion !== "success" /* Success */
+    );
+    if (failed.length > 0) {
+      inconclusive.push(...failed);
+    } else if (named.length > 0 && named.every((job) => job.status === "completed")) {
+      concluded.push(...named);
+    } else {
+      missing.push(name);
+    }
+  }
+  if (inconclusive.length > 0) {
+    for (const job of inconclusive) {
+      error(
+        `Job ${job.name} has failed with conclusion: ${String(job.conclusion)}`
+      );
+    }
+    return {
+      done: true,
+      value: { success: false, reason: "inconclusive", value: inconclusive }
+    };
+  }
+  if (missing.length === 0) {
+    return { done: true, value: { success: true, value: concluded } };
+  }
+  if (runCompleted) {
+    const observed = jobs.map((job) => job.name);
+    error(
+      `Run concluded without the awaited Jobs completing:
+  Awaited: [${missing.join(", ")}]
+  Jobs in run: [${observed.join(", ")}]`
+    );
+    return {
+      done: true,
+      value: {
+        success: false,
+        reason: "missing",
+        value: { missing, observed }
+      }
+    };
+  }
+  return POLL_PENDING;
+}
+async function getWorkflowRunJobsResult(opts) {
+  let runCompletedLastPoll = false;
+  const result = await pollRun(opts, async (attemptNo) => {
+    const statesResult = await retryOnError(
+      async () => Promise.all([
+        fetchWorkflowRunState(opts.runId),
+        fetchWorkflowRunJobStates(opts.runId)
+      ]),
+      400,
+      "fetchWorkflowRunState & fetchWorkflowRunJobStates"
+    );
+    if (!statesResult.success) {
+      debug(`Failed to fetch run state and Jobs, attempt ${attemptNo}...`);
+      return POLL_PENDING;
+    }
+    const [runState, jobs] = statesResult.value;
+    const runCompleted = runState.status === "completed" /* Completed */;
+    const completionConfirmed = runCompleted && runCompletedLastPoll;
+    runCompletedLastPoll = runCompleted;
+    return getWorkflowRunJobsStateResult(opts.jobs, jobs, completionConfirmed);
+  });
+  if (!result.success && result.reason === "inconclusive" && opts.cancelTimeoutMs !== void 0) {
+    warning(
+      `Awaited Jobs have concluded unsuccessfully, requesting cancellation of Workflow Run ${opts.runId}`
+    );
+    await requestWorkflowRunCancel(opts.runId);
+  }
+  return result;
+}
 
 // src/main.ts
+async function handleJobsResult(result, runId, startTime) {
+  if (result.success) {
+    const names = result.value.map((job) => job.name);
+    info(
+      `Awaited Jobs Completed:
+  Run ID: ${runId}
+  Jobs: [${names.join(", ")}]`
+    );
+    return;
+  }
+  let failureMsg;
+  switch (result.reason) {
+    case "timeout": {
+      const elapsedTime = Date.now() - startTime;
+      failureMsg = `Timeout exceeded while attempting to await the Jobs concluding (${elapsedTime}ms)`;
+      break;
+    }
+    case "inconclusive": {
+      const failed = result.value.map((job) => `${job.name} (${String(job.conclusion)})`).join(", ");
+      failureMsg = `Awaited Jobs have concluded unsuccessfully: ${failed}`;
+      break;
+    }
+    case "missing": {
+      failureMsg = `Run concluded without the awaited Jobs completing: ${result.value.missing.join(", ")}`;
+      break;
+    }
+  }
+  await handleActionFail(failureMsg, runId);
+}
 async function main() {
   try {
     const startTime = Date.now();
@@ -24415,18 +24568,28 @@ async function main() {
       );
     }
     const runUrl = `https://github.com/${config2.owner}/${config2.repo}/actions/runs/${config2.runId}`;
+    const awaiting = config2.jobs === void 0 ? `Workflow Run ${config2.runId}` : `Jobs [${config2.jobs.join(", ")}] in Workflow Run ${config2.runId}`;
     info(
-      `Awaiting completion of Workflow Run ${config2.runId}...
+      `Awaiting completion of ${awaiting}...
   ID: ${config2.runId}
   URL: ${activeJobUrlResult.success ? activeJobUrlResult.value : runUrl}`
     );
-    const runResult = await getWorkflowRunResult({
+    const runOpts = {
       startTime,
       pollIntervalMs: config2.pollIntervalMs,
       runId: config2.runId,
       runTimeoutMs: config2.runTimeoutSeconds * 1e3,
       cancelTimeoutMs: config2.cancelTimeoutSeconds === void 0 ? void 0 : config2.cancelTimeoutSeconds * 1e3
-    });
+    };
+    if (config2.jobs !== void 0) {
+      const jobsResult = await getWorkflowRunJobsResult({
+        ...runOpts,
+        jobs: config2.jobs
+      });
+      await handleJobsResult(jobsResult, config2.runId, startTime);
+      return;
+    }
+    const runResult = await getWorkflowRunResult(runOpts);
     if (!runResult.success) {
       const elapsedTime = Date.now() - startTime;
       const failureMsg = runResult.reason === "timeout" ? `Timeout exceeded while attempting to await run conclusion (${elapsedTime}ms)` : `An unsupported value was reached: ${runResult.value}`;

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -22,6 +22,7 @@ describe("Action", () => {
         run_timeout_seconds: "300",
         cancel_timeout_seconds: "",
         poll_interval_ms: "2500",
+        jobs: "",
       };
 
       vi.spyOn(core, "getInput").mockImplementation((input: string) => {
@@ -41,6 +42,8 @@ describe("Action", () => {
             return mockEnvConfig.cancel_timeout_seconds;
           case "poll_interval_ms":
             return mockEnvConfig.poll_interval_ms;
+          case "jobs":
+            return mockEnvConfig.jobs;
           default:
             throw new Error("invalid input requested");
         }
@@ -64,9 +67,70 @@ describe("Action", () => {
       expect(config.runTimeoutSeconds).toStrictEqual(300);
       expect(config.cancelTimeoutSeconds).toBeUndefined();
       expect(config.pollIntervalMs).toStrictEqual(2500);
+      expect(config.jobs).toBeUndefined();
 
       // Logging
       assertNoneCalled();
+    });
+
+    describe("jobs", () => {
+      it("should split jobs on newlines", () => {
+        mockEnvConfig.jobs = "build\ntest\n";
+
+        // Behaviour
+        const config: ActionConfig = getConfig();
+        expect(config.jobs).toStrictEqual(["build", "test"]);
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it("should not split a matrix job name on its commas", () => {
+        mockEnvConfig.jobs = "build (ubuntu-latest, 20)";
+
+        // Behaviour
+        const config: ActionConfig = getConfig();
+        expect(config.jobs).toStrictEqual(["build (ubuntu-latest, 20)"]);
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it("should trim surrounding whitespace and drop blank entries", () => {
+        mockEnvConfig.jobs = "  build  \n\n   \n\ttest\t\n";
+
+        // Behaviour
+        const config: ActionConfig = getConfig();
+        expect(config.jobs).toStrictEqual(["build", "test"]);
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it("should discard duplicate job names", () => {
+        mockEnvConfig.jobs = "build\ntest\nbuild";
+
+        // Behaviour
+        const config: ActionConfig = getConfig();
+        expect(config.jobs).toStrictEqual(["build", "test"]);
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it.each([
+        { jobs: "", label: "an empty input" },
+        { jobs: "\n  \n", label: "only blanks" },
+      ])("should be undefined for $label", ({ jobs }) => {
+        mockEnvConfig.jobs = jobs;
+
+        // Behaviour
+        const config: ActionConfig = getConfig();
+        expect(config.jobs).toBeUndefined();
+
+        // Logging
+        assertNoneCalled();
+      });
     });
 
     it("should return cancel_timeout_seconds if one is supplied", () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -47,6 +47,25 @@ export interface ActionConfig {
    * @default 2500
    */
   pollIntervalMs: number;
+
+  /**
+   * Names of Jobs to await, instead of the whole run.
+   *
+   * Matched against the name GitHub reports, not the workflow's job key.
+   *
+   * @example
+   * ```yaml
+   * jobs: |
+   *   build
+   *   test (ubuntu-latest, 20)
+   *   lint / eslint
+   * ```
+   * Parses to `["build", "test (ubuntu-latest, 20)", "lint / eslint"]`: a
+   * plain Job, a matrix Job, and a reusable workflow call.
+   *
+   * @default undefined
+   */
+  jobs?: string[];
 }
 
 export function getConfig(): ActionConfig {
@@ -82,7 +101,22 @@ export function getConfig(): ActionConfig {
     cancelTimeoutSeconds,
     pollIntervalMs:
       getNumberFromValue(core.getInput("poll_interval_ms")) ?? POLL_INTERVAL_MS,
+    jobs: getJobsFromValue(core.getInput("jobs")),
   };
+}
+
+/**
+ * Split on newlines only, as a matrix Job carries commas in its name.
+ */
+function getJobsFromValue(value: string): string[] | undefined {
+  const jobs = new Set(
+    value
+      .split("\n")
+      .map((job) => job.trim())
+      .filter((job) => job !== ""),
+  );
+
+  return jobs.size > 0 ? [...jobs] : undefined;
 }
 
 function getRunIdFromValue(value: string): number {

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -14,6 +14,7 @@ import {
   fetchWorkflowRunActiveJobUrl,
   fetchWorkflowRunActiveJobUrlRetry,
   fetchWorkflowRunFailedJobs,
+  fetchWorkflowRunJobStates,
   fetchWorkflowRunState,
   init,
   requestWorkflowRunCancel,
@@ -424,6 +425,116 @@ describe("API", () => {
 
         // Logging
         assertOnlyCalled(coreDebugLogMock);
+      });
+    });
+
+    describe("fetchWorkflowRunJobStates", () => {
+      it("should return the name, status, and conclusion of every job", async () => {
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockReturnValue(
+          Promise.resolve({
+            data: {
+              total_count: 2,
+              jobs: [
+                {
+                  id: 0,
+                  html_url: null,
+                  status: "completed",
+                  conclusion: "success",
+                  name: "build",
+                  steps: [],
+                },
+                {
+                  id: 1,
+                  html_url: null,
+                  status: "in_progress",
+                  conclusion: null,
+                  name: "deploy",
+                  steps: [],
+                },
+              ],
+            },
+            status: 200,
+            headers: {},
+          }),
+        );
+
+        // Behaviour
+        const jobs = await fetchWorkflowRunJobStates(123456);
+        expect(jobs).toStrictEqual([
+          { name: "build", status: "completed", conclusion: "success" },
+          { name: "deploy", status: "in_progress", conclusion: null },
+        ]);
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+        expect(coreDebugLogMock).toHaveBeenCalledOnce();
+        expect(coreDebugLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+          "Fetched Job states for Run:
+            Repository: owner/repository
+            Run ID: 123456
+            Jobs: [build (completed, success), deploy (in_progress, null)]"
+        `);
+      });
+
+      it("should page the listing, as a name can match any job in the run", async () => {
+        const paginateMock = vi.spyOn(mockOctokit, "paginate");
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockReturnValue(
+          Promise.resolve({ data: mockData, status: 200, headers: {} }),
+        );
+
+        // Behaviour
+        await fetchWorkflowRunJobStates(123456);
+        expect(paginateMock).toHaveBeenCalledOnce();
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+      });
+
+      it("should return no jobs for a run yet to create any", async () => {
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockReturnValue(
+          Promise.resolve({
+            data: { total_count: 0, jobs: [] },
+            status: 200,
+            headers: {},
+          }),
+        );
+
+        // Behaviour
+        // An empty list is an ordinary early state, not a failure.
+        await expect(fetchWorkflowRunJobStates(123456)).resolves.toStrictEqual(
+          [],
+        );
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+      });
+
+      it("should log and rethrow a failed request", async () => {
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockRejectedValue(mockHttpError("Bad credentials", 401));
+
+        // Behaviour
+        await expect(fetchWorkflowRunJobStates(0)).rejects.toThrow(
+          "Bad credentials",
+        );
+
+        // Logging
+        assertOnlyCalled(coreErrorLogMock, coreDebugLogMock);
+        expect(coreErrorLogMock).toHaveBeenCalledOnce();
+        expect(coreErrorLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+          `"fetchWorkflowRunJobStates: An unexpected error has occurred: Bad credentials"`,
+        );
       });
     });
 

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -574,7 +574,7 @@ describe("API", () => {
         `);
       });
 
-      it("should log a warning if no failed jobs are found", async () => {
+      it("should log info if no unsuccessful jobs are found", async () => {
         vi.spyOn(
           mockOctokit.rest.actions,
           "listJobsForWorkflowRun",
@@ -590,15 +590,48 @@ describe("API", () => {
         );
 
         // Behaviour
+        // Routine when the awaited Jobs concluded skipped or went missing.
         const jobs = await fetchWorkflowRunFailedJobs(123456);
         expect(jobs).toHaveLength(0);
 
         // Logging
-        assertOnlyCalled(coreWarningLogMock);
-        expect(coreWarningLogMock).toHaveBeenCalledOnce();
-        expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
-          `"Failed to find failed Jobs for Workflow Run 123456"`,
+        assertOnlyCalled(coreInfoLogMock);
+        expect(coreInfoLogMock).toHaveBeenCalledOnce();
+        expect(coreInfoLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+          `"Found no unsuccessful Jobs for Workflow Run 123456"`,
         );
+      });
+
+      it("should return unsuccessful jobs beyond conclusion failure", async () => {
+        const job = (name: string, status: string, conclusion: string | null) =>
+          ({ ...mockData.jobs[0]!, name, status, conclusion }) as object;
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockReturnValue(
+          Promise.resolve({
+            headers: {},
+            data: {
+              total_count: 5,
+              jobs: [
+                job("build", "completed", "failure"),
+                job("test", "completed", "cancelled"),
+                // Excluded: no diagnostic detail, or yet to conclude.
+                job("lint", "completed", "skipped"),
+                job("succeeded", "completed", "success"),
+                job("deploy", "in_progress", null),
+              ],
+            },
+            status: 200,
+          }),
+        );
+
+        // Behaviour
+        const jobs = await fetchWorkflowRunFailedJobs(123456);
+        expect(jobs.map(({ name }) => name)).toStrictEqual(["build", "test"]);
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
       });
 
       it("should log and rethrow a failed request", async () => {

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -32,6 +32,18 @@ interface MockResponse {
 }
 
 const mockOctokit = {
+  /**
+   * Stands in for the paginate plugin, flattening the mocked page. Walking the
+   * `Link` header is Octokit's contract to keep, not ours to test.
+   */
+  paginate: async (
+    endpoint: (req?: any) => Promise<MockResponse>,
+    params?: any,
+  ): Promise<unknown[]> => {
+    const response = await endpoint(params);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return response.data.jobs;
+  },
   rest: {
     actions: {
       getWorkflowRun: (_req?: any): Promise<MockResponse> => {
@@ -367,6 +379,54 @@ describe("API", () => {
       ],
     };
 
+    describe("pagination", () => {
+      it("should page the listing at the maximum size", async () => {
+        const paginateMock = vi.spyOn(mockOctokit, "paginate");
+        vi.spyOn(
+          mockOctokit.rest.actions,
+          "listJobsForWorkflowRun",
+        ).mockReturnValue(
+          Promise.resolve({ data: mockData, status: 200, headers: {} }),
+        );
+
+        // Behaviour
+        // A single default-sized page would discard every Job past the 30th.
+        await fetchWorkflowRunFailedJobs(123456);
+
+        expect(paginateMock).toHaveBeenCalledOnce();
+        expect(paginateMock.mock.lastCall?.[0]).toBe(
+          mockOctokit.rest.actions.listJobsForWorkflowRun,
+        );
+        expect(paginateMock.mock.lastCall?.[1]).toMatchObject({
+          run_id: 123456,
+          filter: "latest",
+          per_page: constants.JOBS_PER_PAGE,
+        });
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+      });
+
+      it("should not page the listing to resolve the active Job URL", async () => {
+        const paginateMock = vi.spyOn(mockOctokit, "paginate");
+        const listJobsMock = vi
+          .spyOn(mockOctokit.rest.actions, "listJobsForWorkflowRun")
+          .mockReturnValue(
+            Promise.resolve({ data: mockData, status: 200, headers: {} }),
+          );
+
+        // Behaviour
+        // Polled every second while the run starts, for a single Job.
+        await fetchWorkflowRunActiveJobUrl(123456);
+
+        expect(listJobsMock).toHaveBeenCalledOnce();
+        expect(paginateMock).not.toHaveBeenCalled();
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+      });
+    });
+
     describe("fetchWorkflowRunFailedJobs", () => {
       it("should return the jobs for a failed workflow run given a run ID", async () => {
         vi.spyOn(
@@ -430,29 +490,22 @@ describe("API", () => {
         );
       });
 
-      it("should throw if a non-200 status is returned", async () => {
-        const errorStatus = 401;
+      it("should log and rethrow a failed request", async () => {
         vi.spyOn(
           mockOctokit.rest.actions,
           "listJobsForWorkflowRun",
-        ).mockReturnValue(
-          Promise.resolve({
-            data: undefined,
-            status: errorStatus,
-            headers: {},
-          }),
-        );
+        ).mockRejectedValue(mockHttpError("Bad credentials", 401));
 
         // Behaviour
         await expect(fetchWorkflowRunFailedJobs(0)).rejects.toThrow(
-          `Failed to fetch Jobs for Workflow Run, expected 200 but received ${errorStatus}`,
+          "Bad credentials",
         );
 
         // Logging
         assertOnlyCalled(coreErrorLogMock, coreDebugLogMock);
         expect(coreErrorLogMock).toHaveBeenCalledOnce();
         expect(coreErrorLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
-          `"fetchWorkflowRunFailedJobs: An unexpected error has occurred: Failed to fetch Jobs for Workflow Run, expected 200 but received 401"`,
+          `"fetchWorkflowRunFailedJobs: An unexpected error has occurred: Bad credentials"`,
         );
         expect(coreDebugLogMock).toHaveBeenCalledOnce();
       });
@@ -554,29 +607,22 @@ describe("API", () => {
         `);
       });
 
-      it("should throw if a non-200 status is returned", async () => {
-        const errorStatus = 401;
+      it("should log and rethrow a failed request", async () => {
         vi.spyOn(
           mockOctokit.rest.actions,
           "listJobsForWorkflowRun",
-        ).mockReturnValue(
-          Promise.resolve({
-            data: undefined,
-            status: errorStatus,
-            headers: {},
-          }),
-        );
+        ).mockRejectedValue(mockHttpError("Bad credentials", 401));
 
         // Behaviour
         await expect(fetchWorkflowRunActiveJobUrl(0)).rejects.toThrow(
-          `Failed to fetch Jobs for Workflow Run, expected 200 but received ${errorStatus}`,
+          "Bad credentials",
         );
 
         // Logging
         assertOnlyCalled(coreErrorLogMock, coreDebugLogMock);
         expect(coreErrorLogMock).toHaveBeenCalledOnce();
         expect(coreErrorLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
-          `"fetchWorkflowRunActiveJobUrl: An unexpected error has occurred: Failed to fetch Jobs for Workflow Run, expected 200 but received 401"`,
+          `"fetchWorkflowRunActiveJobUrl: An unexpected error has occurred: Bad credentials"`,
         );
         expect(coreDebugLogMock).toHaveBeenCalledOnce();
       });

--- a/src/api.ts
+++ b/src/api.ts
@@ -318,6 +318,50 @@ export async function fetchWorkflowRunFailedJobs(
   }
 }
 
+export interface WorkflowRunJobState {
+  name: string;
+  status: ListedJob["status"];
+  conclusion: ListedJob["conclusion"];
+}
+
+/**
+ * Fetch the state of every Job the run has created so far.
+ *
+ * Jobs appear as they become eligible, so one blocked on `needs` is absent
+ * rather than pending.
+ */
+export async function fetchWorkflowRunJobStates(
+  runId: number,
+): Promise<WorkflowRunJobState[]> {
+  try {
+    const jobs = (await fetchWorkflowRunJobs(runId)).map((job) => ({
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion,
+    }));
+
+    const jobStates = jobs.map(
+      (job) => `${job.name} (${job.status}, ${job.conclusion})`,
+    );
+    core.debug(
+      `Fetched Job states for Run:\n` +
+        `  Repository: ${config.owner}/${config.repo}\n` +
+        `  Run ID: ${runId}\n` +
+        `  Jobs: [${jobStates.join(", ")}]`,
+    );
+
+    return jobs;
+  } catch (error) {
+    if (error instanceof Error) {
+      core.error(
+        `fetchWorkflowRunJobStates: An unexpected error has occurred: ${error.message}`,
+      );
+      core.debug(error.stack ?? "");
+    }
+    throw error;
+  }
+}
+
 export async function fetchWorkflowRunActiveJobUrl(
   runId: number,
 ): Promise<string | undefined> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -217,34 +217,50 @@ type ListJobsForWorkflowRunResponse = Awaited<
   ReturnType<Octokit["rest"]["actions"]["listJobsForWorkflowRun"]>
 >;
 
-async function fetchWorkflowRunJobs(
+type ListedJob = ListJobsForWorkflowRunResponse["data"]["jobs"][number];
+
+/**
+ * Fetch every Job the run has created.
+ *
+ * Costs a request per `JOBS_PER_PAGE` Jobs, so prefer
+ * `fetchWorkflowRunJobsFirstPage` where any one Job will do.
+ */
+async function fetchWorkflowRunJobs(runId: number): Promise<ListedJob[]> {
+  // https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
+  return octokit.paginate(octokit.rest.actions.listJobsForWorkflowRun, {
+    owner: config.owner,
+    repo: config.repo,
+    run_id: runId,
+    filter: "latest",
+    per_page: constants.JOBS_PER_PAGE,
+  });
+}
+
+/**
+ * Fetch the first page of the run's Jobs.
+ *
+ * Jobs are listed oldest first, so the earliest to start are here.
+ */
+async function fetchWorkflowRunJobsFirstPage(
   runId: number,
-): Promise<ListJobsForWorkflowRunResponse> {
+): Promise<ListedJob[]> {
   // https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run
   const response = await octokit.rest.actions.listJobsForWorkflowRun({
     owner: config.owner,
     repo: config.repo,
     run_id: runId,
     filter: "latest",
+    per_page: constants.JOBS_PER_PAGE,
   });
 
-  // A non-200 is possible, the types aren't the best
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (response.status !== 200) {
-    throw new Error(
-      `Failed to fetch Jobs for Workflow Run, expected 200 but received ${response.status}`,
-    );
-  }
-
-  return response;
+  return response.data.jobs;
 }
 
 export async function fetchWorkflowRunFailedJobs(
   runId: number,
 ): Promise<WorkflowRunJob[]> {
   try {
-    const response = await fetchWorkflowRunJobs(runId);
-    const fetchedFailedJobs = response.data.jobs.filter(
+    const fetchedFailedJobs = (await fetchWorkflowRunJobs(runId)).filter(
       (job) => job.conclusion === "failure",
     );
 
@@ -306,8 +322,9 @@ export async function fetchWorkflowRunActiveJobUrl(
   runId: number,
 ): Promise<string | undefined> {
   try {
-    const response = await fetchWorkflowRunJobs(runId);
-    const fetchedInProgressJobs = response.data.jobs.filter(
+    const fetchedInProgressJobs = (
+      await fetchWorkflowRunJobsFirstPage(runId)
+    ).filter(
       (job) => job.status === "in_progress" || job.status === "completed",
     );
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -256,16 +256,25 @@ async function fetchWorkflowRunJobsFirstPage(
   return response.data.jobs;
 }
 
+/**
+ * Fetch the run's Jobs that concluded unsuccessfully, for failure diagnostics.
+ *
+ * Skipped Jobs are excluded, as they carry no diagnostic detail and would bury
+ * the causal failure.
+ */
 export async function fetchWorkflowRunFailedJobs(
   runId: number,
 ): Promise<WorkflowRunJob[]> {
   try {
     const fetchedFailedJobs = (await fetchWorkflowRunJobs(runId)).filter(
-      (job) => job.conclusion === "failure",
+      (job) =>
+        job.status === "completed" &&
+        job.conclusion !== "success" &&
+        job.conclusion !== "skipped",
     );
 
     if (fetchedFailedJobs.length <= 0) {
-      core.warning(`Failed to find failed Jobs for Workflow Run ${runId}`);
+      core.info(`Found no unsuccessful Jobs for Workflow Run ${runId}`);
       return [];
     }
 

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -1062,9 +1062,42 @@ describe("await-remote-run", () => {
           reason: "missing",
           value: { missing: ["deploy"], observed: ["build"] },
         });
+        // Completion must hold for two polls before `missing` is terminal.
+        expect(apiFetchWorkflowRunJobStatesMock).toHaveBeenCalledTimes(2);
 
         // Logging
         assertOnlyCalled(coreErrorLogMock);
+      });
+
+      it("succeeds when the Jobs listing lags the run completing", async () => {
+        apiFetchWorkflowRunStateMock.mockResolvedValue({
+          status: WorkflowRunStatus.Completed,
+          conclusion: WorkflowRunConclusion.Success,
+        });
+        // The awaited Job succeeded, but the listing has yet to reflect it.
+        apiFetchWorkflowRunJobStatesMock
+          .mockResolvedValue([succeeded])
+          .mockResolvedValueOnce([
+            { name: "build", status: "in_progress", conclusion: null },
+          ]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          jobs: ["build"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toStrictEqual({
+          success: true,
+          value: [succeeded],
+        });
+
+        // Logging
+        assertNoneCalled();
       });
 
       it("times out while the awaited Job never completes", async () => {

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -1200,7 +1200,7 @@ describe("await-remote-run", () => {
         assertOnlyCalled(coreDebugLogMock);
         expect(coreDebugLogMock).toHaveBeenCalledOnce();
         expect(coreDebugLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
-          `"Failed to fetch run Jobs, attempt 1..."`,
+          `"Failed to fetch run state and Jobs, attempt 1..."`,
         );
       });
     });

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -337,6 +337,39 @@ describe("await-remote-run", () => {
       assertNoneCalled();
     });
 
+    describe("duplicate Job names", () => {
+      it("should not let a success mask a same-named failure", () => {
+        const failed = job("build", "completed", "failure");
+
+        // Behaviour
+        const result = getWorkflowRunJobsStateResult(
+          ["build"],
+          [build, failed],
+          false,
+        );
+        expect(result).toStrictEqual({
+          done: true,
+          value: { success: false, reason: "inconclusive", value: [failed] },
+        });
+
+        // Logging
+        assertOnlyCalled(coreErrorLogMock);
+      });
+
+      it("should await every Job bearing an awaited name", () => {
+        // Behaviour
+        const result = getWorkflowRunJobsStateResult(
+          ["build"],
+          [build, job("build", "in_progress")],
+          false,
+        );
+        expect(result).toStrictEqual({ done: false });
+
+        // Logging
+        assertNoneCalled();
+      });
+    });
+
     it("should fail once the run concludes without an awaited Job", () => {
       // Behaviour
       const result = getWorkflowRunJobsStateResult(

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -11,8 +11,11 @@ import {
 } from "vitest";
 
 import * as api from "./api.ts";
+import type { WorkflowRunJobState } from "./api.ts";
 import {
   getWorkflowRunConclusionResult,
+  getWorkflowRunJobsResult,
+  getWorkflowRunJobsStateResult,
   getWorkflowRunResult,
   getWorkflowRunStatusResult,
   handleActionFail,
@@ -243,6 +246,137 @@ describe("await-remote-run", () => {
       expect(coreErrorLogMock.mock.lastCall?.[0]).toStrictEqual(
         `Run has failed with conclusion: ${conclusion}`,
       );
+    });
+  });
+
+  describe("getWorkflowRunJobsStateResult", () => {
+    function job(
+      name: string,
+      status: WorkflowRunJobState["status"],
+      conclusion: WorkflowRunJobState["conclusion"] = null,
+    ): WorkflowRunJobState {
+      return { name: name, status: status, conclusion: conclusion };
+    }
+
+    const build = job("build", "completed", "success");
+
+    it("should settle once every awaited Job has succeeded", () => {
+      const test = job("test", "completed", "success");
+
+      // Behaviour
+      const result = getWorkflowRunJobsStateResult(
+        ["build", "test"],
+        [build, test, job("deploy", "in_progress")],
+        false,
+      );
+      expect(result).toStrictEqual({
+        done: true,
+        value: { success: true, value: [build, test] },
+      });
+
+      // Logging
+      assertNoneCalled();
+    });
+
+    it.each(["failure", "cancelled", "skipped", "timed_out"] as const)(
+      "should fail on an awaited Job concluding %s",
+      (conclusion) => {
+        const failed = job("build", "completed", conclusion);
+
+        // Behaviour
+        const result = getWorkflowRunJobsStateResult(
+          ["build"],
+          [failed],
+          false,
+        );
+        expect(result).toStrictEqual({
+          done: true,
+          value: { success: false, reason: "inconclusive", value: [failed] },
+        });
+
+        // Logging
+        assertOnlyCalled(coreErrorLogMock);
+        expect(coreErrorLogMock).toHaveBeenCalledOnce();
+        expect(coreErrorLogMock.mock.lastCall?.[0]).toStrictEqual(
+          `Job build has failed with conclusion: ${conclusion}`,
+        );
+      },
+    );
+
+    it("should fail without waiting on the remaining awaited Jobs", () => {
+      // Behaviour
+      // `test` has yet to appear, but cannot rescue `build`.
+      const result = getWorkflowRunJobsStateResult(
+        ["build", "test"],
+        [job("build", "completed", "failure")],
+        false,
+      );
+      expect(result).toMatchObject({
+        done: true,
+        value: { reason: "inconclusive" },
+      });
+
+      // Logging
+      assertOnlyCalled(coreErrorLogMock);
+    });
+
+    it.each([
+      { label: "not yet appeared", pending: [] },
+      { label: "yet to complete", pending: [job("test", "in_progress")] },
+      { label: "queued", pending: [job("test", "queued")] },
+    ])("should keep polling while an awaited Job has $label", ({ pending }) => {
+      // Behaviour
+      const result = getWorkflowRunJobsStateResult(
+        ["build", "test"],
+        [build, ...pending],
+        false,
+      );
+      expect(result).toStrictEqual({ done: false });
+
+      // Logging
+      assertNoneCalled();
+    });
+
+    it("should fail once the run concludes without an awaited Job", () => {
+      // Behaviour
+      const result = getWorkflowRunJobsStateResult(
+        ["build", "tset"],
+        [build, job("test", "completed", "success")],
+        true,
+      );
+      expect(result).toStrictEqual({
+        done: true,
+        value: {
+          success: false,
+          reason: "missing",
+          value: { missing: ["tset"], observed: ["build", "test"] },
+        },
+      });
+
+      // Logging
+      assertOnlyCalled(coreErrorLogMock);
+      expect(coreErrorLogMock).toHaveBeenCalledOnce();
+      expect(coreErrorLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+        "Run concluded without the awaited Jobs completing:
+          Awaited: [tset]
+          Jobs in run: [build, test]"
+      `);
+    });
+
+    it("should report a Job the run abandoned mid-flight as missing", () => {
+      // Behaviour
+      const result = getWorkflowRunJobsStateResult(
+        ["test"],
+        [job("test", "in_progress")],
+        true,
+      );
+      expect(result).toMatchObject({
+        done: true,
+        value: { reason: "missing", value: { missing: ["test"] } },
+      });
+
+      // Logging
+      assertOnlyCalled(coreErrorLogMock);
     });
   });
 
@@ -823,6 +957,171 @@ describe("await-remote-run", () => {
 
         // Logging
         assertNoneCalled();
+      });
+    });
+
+    describe("getWorkflowRunJobsResult", () => {
+      const pollIntervalMs = 100;
+      const runTimeoutMs = 1000;
+      const succeeded = {
+        name: "build",
+        status: "completed",
+        conclusion: "success",
+      } satisfies WorkflowRunJobState;
+
+      let apiFetchWorkflowRunJobStatesMock: MockInstance<
+        typeof api.fetchWorkflowRunJobStates
+      >;
+
+      beforeEach(() => {
+        apiFetchWorkflowRunJobStatesMock = vi.spyOn(
+          api,
+          "fetchWorkflowRunJobStates",
+        );
+        apiRetryOnErrorMock.mockImplementation(async (toTry) => ({
+          success: true,
+          value: await toTry(),
+        }));
+        apiFetchWorkflowRunStateMock.mockResolvedValue({
+          status: WorkflowRunStatus.InProgress,
+          conclusion: null,
+        });
+      });
+
+      it("resolves while the rest of the run is still in flight", async () => {
+        apiFetchWorkflowRunJobStatesMock.mockResolvedValue([
+          succeeded,
+          { name: "deploy", status: "in_progress", conclusion: null },
+        ]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          jobs: ["build"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toStrictEqual({
+          success: true,
+          value: [succeeded],
+        });
+        // Resolving early never cancels the run the deploy is still using.
+        expect(apiRequestWorkflowRunCancelMock).not.toHaveBeenCalled();
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it("polls until the awaited Job appears", async () => {
+        apiFetchWorkflowRunJobStatesMock
+          .mockResolvedValue([succeeded])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([
+            { name: "build", status: "in_progress", conclusion: null },
+          ]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          jobs: ["build"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toMatchObject({ success: true });
+        expect(apiFetchWorkflowRunJobStatesMock).toHaveBeenCalledTimes(3);
+
+        // Logging
+        assertNoneCalled();
+      });
+
+      it("fails once the run concludes without the awaited Job", async () => {
+        apiFetchWorkflowRunStateMock.mockResolvedValue({
+          status: WorkflowRunStatus.Completed,
+          conclusion: WorkflowRunConclusion.Success,
+        });
+        apiFetchWorkflowRunJobStatesMock.mockResolvedValue([succeeded]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          jobs: ["deploy"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toStrictEqual({
+          success: false,
+          reason: "missing",
+          value: { missing: ["deploy"], observed: ["build"] },
+        });
+
+        // Logging
+        assertOnlyCalled(coreErrorLogMock);
+      });
+
+      it("times out while the awaited Job never completes", async () => {
+        apiRequestWorkflowRunCancelMock.mockResolvedValue({ success: true });
+        apiFetchWorkflowRunJobStatesMock.mockResolvedValue([
+          { name: "build", status: "in_progress", conclusion: null },
+        ]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          cancelTimeoutMs: 300,
+          jobs: ["build"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toStrictEqual({
+          success: false,
+          reason: "timeout",
+        });
+        // Cancellation still applies to the timeout path.
+        expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledOnce();
+
+        // Logging
+        assertOnlyCalled(coreWarningLogMock);
+      });
+
+      it("retries on request failures", async () => {
+        apiRetryOnErrorMock
+          .mockImplementation(async (toTry) => ({
+            success: true,
+            value: await toTry(),
+          }))
+          .mockResolvedValueOnce({ success: false, reason: "timeout" });
+        apiFetchWorkflowRunJobStatesMock.mockResolvedValue([succeeded]);
+
+        // Behaviour
+        const resultPromise = getWorkflowRunJobsResult({
+          startTime: Date.now(),
+          pollIntervalMs: pollIntervalMs,
+          runId: 0,
+          runTimeoutMs: runTimeoutMs,
+          jobs: ["build"],
+        });
+        await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+        expect(await resultPromise).toMatchObject({ success: true });
+
+        // Logging
+        assertOnlyCalled(coreDebugLogMock);
+        expect(coreDebugLogMock).toHaveBeenCalledOnce();
+        expect(coreDebugLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+          `"Failed to fetch run Jobs, attempt 1..."`,
+        );
       });
     });
 

--- a/src/await-remote-run.spec.ts
+++ b/src/await-remote-run.spec.ts
@@ -1100,6 +1100,53 @@ describe("await-remote-run", () => {
         assertNoneCalled();
       });
 
+      it.each([
+        { cancelTimeoutMs: 300, cancelRequests: 1, label: "cancels the run" },
+        {
+          cancelTimeoutMs: undefined,
+          cancelRequests: 0,
+          label: "leaves the run in flight",
+        },
+      ])(
+        "$label once an awaited Job fails with cancel_timeout_seconds $cancelTimeoutMs",
+        async ({ cancelTimeoutMs, cancelRequests }) => {
+          apiRequestWorkflowRunCancelMock.mockResolvedValue({ success: true });
+          apiFetchWorkflowRunJobStatesMock.mockResolvedValue([
+            { name: "build", status: "completed", conclusion: "failure" },
+          ]);
+
+          // Behaviour
+          const resultPromise = getWorkflowRunJobsResult({
+            startTime: Date.now(),
+            pollIntervalMs: pollIntervalMs,
+            runId: 0,
+            runTimeoutMs: runTimeoutMs,
+            cancelTimeoutMs: cancelTimeoutMs,
+            jobs: ["build"],
+          });
+          await vi.advanceTimersByTimeAsync(runTimeoutMs);
+
+          expect(await resultPromise).toMatchObject({
+            success: false,
+            reason: "inconclusive",
+          });
+          expect(apiRequestWorkflowRunCancelMock).toHaveBeenCalledTimes(
+            cancelRequests,
+          );
+
+          // Logging
+          if (cancelRequests > 0) {
+            assertOnlyCalled(coreErrorLogMock, coreWarningLogMock);
+            expect(coreWarningLogMock).toHaveBeenCalledOnce();
+            expect(coreWarningLogMock.mock.lastCall?.[0]).toMatchInlineSnapshot(
+              `"Awaited Jobs have concluded unsuccessfully, requesting cancellation of Workflow Run 0"`,
+            );
+          } else {
+            assertOnlyCalled(coreErrorLogMock);
+          }
+        },
+      );
+
       it("times out while the awaited Job never completes", async () => {
         apiRequestWorkflowRunCancelMock.mockResolvedValue({ success: true });
         apiFetchWorkflowRunJobStatesMock.mockResolvedValue([

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -246,25 +246,36 @@ export type JobsResult = WorkflowRunJobsResult<WorkflowRunJobState>;
  *
  * A Job absent from `jobs` is only terminal once the run has completed, as
  * until then it may still be created.
+ *
+ * GitHub permits Jobs to share a name, so an awaited name covers every Job
+ * bearing it.
  */
 export function getWorkflowRunJobsStateResult(
   awaited: string[],
   jobs: WorkflowRunJobState[],
   runCompleted: boolean,
 ): PollAttempt<JobsResult> {
-  const byName = new Map(jobs.map((job) => [job.name, job]));
+  const byName = Map.groupBy(jobs, (job) => job.name);
   const concluded: WorkflowRunJobState[] = [];
   const inconclusive: WorkflowRunJobState[] = [];
   const missing: string[] = [];
 
   for (const name of awaited) {
-    const job = byName.get(name);
-    if (job?.status !== "completed") {
-      missing.push(name);
-    } else if (job.conclusion === WorkflowRunConclusion.Success) {
-      concluded.push(job);
+    const named = byName.get(name) ?? [];
+    const failed = named.filter(
+      (job) =>
+        job.status === "completed" &&
+        job.conclusion !== WorkflowRunConclusion.Success,
+    );
+    if (failed.length > 0) {
+      inconclusive.push(...failed);
+    } else if (
+      named.length > 0 &&
+      named.every((job) => job.status === "completed")
+    ) {
+      concluded.push(...named);
     } else {
-      inconclusive.push(job);
+      missing.push(name);
     }
   }
 

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -308,6 +308,9 @@ export function getWorkflowRunJobsStateResult(
 /**
  * Await named Jobs within the run rather than the run itself, resolving once
  * each has succeeded and leaving the rest of the run in flight.
+ *
+ * A Job concluding otherwise fails the result, cancelling the run where
+ * cancellation is configured.
  */
 export async function getWorkflowRunJobsResult(
   opts: RunOpts & { jobs: string[] },
@@ -315,7 +318,7 @@ export async function getWorkflowRunJobsResult(
   // The Jobs listing can briefly lag a freshly completed run, so a `missing`
   // verdict needs completion to hold for two polls before it is terminal.
   let runCompletedLastPoll = false;
-  return pollRun(opts, async (attemptNo) => {
+  const result = await pollRun(opts, async (attemptNo) => {
     const statesResult = await retryOnError(
       async () =>
         Promise.all([
@@ -337,4 +340,19 @@ export async function getWorkflowRunJobsResult(
 
     return getWorkflowRunJobsStateResult(opts.jobs, jobs, completionConfirmed);
   });
+
+  // A failed Job means the run can no longer succeed, so give up on it too
+  // where cancellation was opted into.
+  if (
+    !result.success &&
+    result.reason === "inconclusive" &&
+    opts.cancelTimeoutMs !== undefined
+  ) {
+    core.warning(
+      `Awaited Jobs have concluded unsuccessfully, requesting cancellation of Workflow Run ${opts.runId}`,
+    );
+    await requestWorkflowRunCancel(opts.runId);
+  }
+
+  return result;
 }

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -2,9 +2,11 @@ import * as core from "@actions/core";
 
 import {
   fetchWorkflowRunFailedJobs,
+  fetchWorkflowRunJobStates,
   fetchWorkflowRunState,
   requestWorkflowRunCancel,
   retryOnError,
+  type WorkflowRunJobState,
 } from "./api.ts";
 import {
   POLL_PENDING,
@@ -12,6 +14,7 @@ import {
   WorkflowRunStatus,
   type PollAttempt,
   type WorkflowRunConclusionResult,
+  type WorkflowRunJobsResult,
   type WorkflowRunResult,
   type WorkflowRunStatusResult,
 } from "./types.ts";
@@ -233,5 +236,102 @@ export async function getWorkflowRunResult(
 
     const { status, conclusion } = fetchWorkflowRunStateResult.value;
     return getWorkflowRunStateResult(status, conclusion, attemptNo);
+  });
+}
+
+type JobsResult = WorkflowRunJobsResult<WorkflowRunJobState>;
+
+/**
+ * The result the awaited Jobs settle on, or pending while they have yet to.
+ *
+ * A Job absent from `jobs` is only terminal once the run has completed, as
+ * until then it may still be created.
+ */
+export function getWorkflowRunJobsStateResult(
+  awaited: string[],
+  jobs: WorkflowRunJobState[],
+  runCompleted: boolean,
+): PollAttempt<JobsResult> {
+  const byName = new Map(jobs.map((job) => [job.name, job]));
+  const concluded: WorkflowRunJobState[] = [];
+  const inconclusive: WorkflowRunJobState[] = [];
+  const missing: string[] = [];
+
+  for (const name of awaited) {
+    const job = byName.get(name);
+    if (job?.status !== "completed") {
+      missing.push(name);
+    } else if (job.conclusion === WorkflowRunConclusion.Success) {
+      concluded.push(job);
+    } else {
+      inconclusive.push(job);
+    }
+  }
+
+  // One failed Job settles it, the rest cannot change the outcome.
+  if (inconclusive.length > 0) {
+    for (const job of inconclusive) {
+      core.error(
+        `Job ${job.name} has failed with conclusion: ${String(job.conclusion)}`,
+      );
+    }
+    return {
+      done: true,
+      value: { success: false, reason: "inconclusive", value: inconclusive },
+    };
+  }
+
+  if (missing.length === 0) {
+    return { done: true, value: { success: true, value: concluded } };
+  }
+
+  if (runCompleted) {
+    const observed = jobs.map((job) => job.name);
+    core.error(
+      `Run concluded without the awaited Jobs completing:\n` +
+        `  Awaited: [${missing.join(", ")}]\n` +
+        `  Jobs in run: [${observed.join(", ")}]`,
+    );
+    return {
+      done: true,
+      value: {
+        success: false,
+        reason: "missing",
+        value: { missing, observed },
+      },
+    };
+  }
+
+  return POLL_PENDING;
+}
+
+/**
+ * Await named Jobs within the run rather than the run itself, resolving once
+ * each has succeeded and leaving the rest of the run in flight.
+ */
+export async function getWorkflowRunJobsResult(
+  opts: RunOpts & { jobs: string[] },
+): Promise<JobsResult> {
+  return pollRun(opts, async (attemptNo) => {
+    const statesResult = await retryOnError(
+      async () =>
+        Promise.all([
+          fetchWorkflowRunState(opts.runId),
+          fetchWorkflowRunJobStates(opts.runId),
+        ]),
+      400,
+      "fetchWorkflowRunJobStates",
+    );
+    if (!statesResult.success) {
+      core.debug(`Failed to fetch run Jobs, attempt ${attemptNo}...`);
+      return POLL_PENDING;
+    }
+
+    const [runState, jobs] = statesResult.value;
+    return getWorkflowRunJobsStateResult(
+      opts.jobs,
+      jobs,
+      runState.status === WorkflowRunStatus.Completed,
+    );
   });
 }

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -7,8 +7,10 @@ import {
   retryOnError,
 } from "./api.ts";
 import {
+  POLL_PENDING,
   WorkflowRunConclusion,
   WorkflowRunStatus,
+  type PollAttempt,
   type WorkflowRunConclusionResult,
   type WorkflowRunResult,
   type WorkflowRunStatusResult,
@@ -112,44 +114,55 @@ export async function handleActionFail(
 }
 
 /**
- * The result a fetched state resolves to, or undefined while the run has yet to
+ * The result a fetched state settles on, or pending while the run has yet to
  * resolve and is worth polling for again.
  */
 function getWorkflowRunStateResult(
   status: WorkflowRunStatus | null,
   conclusion: WorkflowRunConclusion | null,
   attemptNo: number,
-): WorkflowRunResult | undefined {
+): PollAttempt<WorkflowRunResult> {
   const statusResult = getWorkflowRunStatusResult(status, attemptNo);
   if (!statusResult.success) {
     // An unsupported status may never resolve, unlike a pending one. Alert to
     // raise this so we can handle it properly.
-    return statusResult.reason === "unsupported" ? statusResult : undefined;
+    return statusResult.reason === "unsupported"
+      ? { done: true, value: statusResult }
+      : POLL_PENDING;
   }
 
   // We only get a conclusion should the status resolve, otherwise it is null.
   const conclusionResult = getWorkflowRunConclusionResult(conclusion);
   if (conclusionResult.success || conclusionResult.reason === "inconclusive") {
     return {
-      success: true,
+      done: true,
       value: {
-        status: statusResult.value,
-        conclusion: conclusionResult.value,
+        success: true,
+        value: {
+          status: statusResult.value,
+          conclusion: conclusionResult.value,
+        },
       },
     };
   }
 
   if (conclusionResult.reason === "timed_out") {
     return {
-      success: false,
-      reason: "timeout",
+      done: true,
+      value: {
+        success: false,
+        reason: "timeout",
+      },
     };
   }
 
   return {
-    success: false,
-    reason: "unsupported",
-    value: conclusionResult.value,
+    done: true,
+    value: {
+      success: false,
+      reason: "unsupported",
+      value: conclusionResult.value,
+    },
   };
 }
 
@@ -160,35 +173,23 @@ interface RunOpts {
   runTimeoutMs: number;
   cancelTimeoutMs?: number;
 }
-export async function getWorkflowRunResult({
-  startTime,
-  runId,
-  runTimeoutMs,
-  pollIntervalMs,
-  cancelTimeoutMs,
-}: RunOpts): Promise<WorkflowRunResult> {
+
+/**
+ * Poll the run until `attempt` settles on a result or the run timeout elapses,
+ * requesting cancellation on the way if one was configured.
+ */
+async function pollRun<T>(
+  { startTime, runId, runTimeoutMs, pollIntervalMs, cancelTimeoutMs }: RunOpts,
+  attempt: (attemptNo: number) => Promise<PollAttempt<T>>,
+): Promise<T | { success: false; reason: "timeout" }> {
   let attemptNo = 0;
   let cancelRequested = false;
   while (Date.now() - startTime < runTimeoutMs) {
     attemptNo++;
 
-    const fetchWorkflowRunStateResult = await retryOnError(
-      async () => fetchWorkflowRunState(runId),
-      400,
-      "fetchWorkflowRunState",
-    );
-    if (fetchWorkflowRunStateResult.success) {
-      const { status, conclusion } = fetchWorkflowRunStateResult.value;
-      const stateResult = getWorkflowRunStateResult(
-        status,
-        conclusion,
-        attemptNo,
-      );
-      if (stateResult !== undefined) {
-        return stateResult;
-      }
-    } else {
-      core.debug(`Failed to fetch run state, attempt ${attemptNo}...`);
+    const attempted = await attempt(attemptNo);
+    if (attempted.done) {
+      return attempted.value;
     }
 
     const elapsedTime = Date.now() - startTime;
@@ -214,4 +215,23 @@ export async function getWorkflowRunResult({
     success: false,
     reason: "timeout",
   };
+}
+
+export async function getWorkflowRunResult(
+  opts: RunOpts,
+): Promise<WorkflowRunResult> {
+  return pollRun(opts, async (attemptNo) => {
+    const fetchWorkflowRunStateResult = await retryOnError(
+      async () => fetchWorkflowRunState(opts.runId),
+      400,
+      "fetchWorkflowRunState",
+    );
+    if (!fetchWorkflowRunStateResult.success) {
+      core.debug(`Failed to fetch run state, attempt ${attemptNo}...`);
+      return POLL_PENDING;
+    }
+
+    const { status, conclusion } = fetchWorkflowRunStateResult.value;
+    return getWorkflowRunStateResult(status, conclusion, attemptNo);
+  });
 }

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -312,6 +312,9 @@ export function getWorkflowRunJobsStateResult(
 export async function getWorkflowRunJobsResult(
   opts: RunOpts & { jobs: string[] },
 ): Promise<JobsResult> {
+  // The Jobs listing can briefly lag a freshly completed run, so a `missing`
+  // verdict needs completion to hold for two polls before it is terminal.
+  let runCompletedLastPoll = false;
   return pollRun(opts, async (attemptNo) => {
     const statesResult = await retryOnError(
       async () =>
@@ -328,10 +331,10 @@ export async function getWorkflowRunJobsResult(
     }
 
     const [runState, jobs] = statesResult.value;
-    return getWorkflowRunJobsStateResult(
-      opts.jobs,
-      jobs,
-      runState.status === WorkflowRunStatus.Completed,
-    );
+    const runCompleted = runState.status === WorkflowRunStatus.Completed;
+    const completionConfirmed = runCompleted && runCompletedLastPoll;
+    runCompletedLastPoll = runCompleted;
+
+    return getWorkflowRunJobsStateResult(opts.jobs, jobs, completionConfirmed);
   });
 }

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -326,10 +326,10 @@ export async function getWorkflowRunJobsResult(
           fetchWorkflowRunJobStates(opts.runId),
         ]),
       400,
-      "fetchWorkflowRunJobStates",
+      "fetchWorkflowRunState & fetchWorkflowRunJobStates",
     );
     if (!statesResult.success) {
-      core.debug(`Failed to fetch run Jobs, attempt ${attemptNo}...`);
+      core.debug(`Failed to fetch run state and Jobs, attempt ${attemptNo}...`);
       return POLL_PENDING;
     }
 

--- a/src/await-remote-run.ts
+++ b/src/await-remote-run.ts
@@ -239,7 +239,7 @@ export async function getWorkflowRunResult(
   });
 }
 
-type JobsResult = WorkflowRunJobsResult<WorkflowRunJobState>;
+export type JobsResult = WorkflowRunJobsResult<WorkflowRunJobState>;
 
 /**
  * The result the awaited Jobs settle on, or pending while they have yet to.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,12 @@ export const WORKFLOW_RUN_ACTIVE_JOB_POLL_INTERVAL_MS: number = 1_000;
 /**
  * How many response bodies to retain for conditional requests.
  *
- * The action only polls a couple of distinct URLs, so this sits well above
- * what a run needs and exists to bound memory should that ever change.
+ * Each Job page is a distinct URL, so this sits well above the pages a run
+ * realistically produces and exists to bound memory.
  */
 export const ETAG_CACHE_MAX_ENTRIES: number = 16;
+
+/**
+ * How many Jobs to request per page, the API maximum.
+ */
+export const JOBS_PER_PAGE: number = 100;

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -60,6 +60,9 @@ describe("main", () => {
   let awaitRemoteRunGetWorkflowRunResult: MockInstance<
     typeof awaitRemoteRun.getWorkflowRunResult
   >;
+  let awaitRemoteRunGetWorkflowRunJobsResult: MockInstance<
+    typeof awaitRemoteRun.getWorkflowRunJobsResult
+  >;
 
   afterAll(() => {
     vi.restoreAllMocks();
@@ -87,6 +90,10 @@ describe("main", () => {
     awaitRemoteRunGetWorkflowRunResult = vi.spyOn(
       awaitRemoteRun,
       "getWorkflowRunResult",
+    );
+    awaitRemoteRunGetWorkflowRunJobsResult = vi.spyOn(
+      awaitRemoteRun,
+      "getWorkflowRunJobsResult",
     );
   });
 
@@ -184,6 +191,142 @@ describe("main", () => {
 
     // Logging
     assertOnlyCalled(coreInfoLogMock);
+  });
+
+  describe("awaiting specific jobs", () => {
+    const jobsCfg: action.ActionConfig = { ...testCfg, jobs: ["build"] };
+    const succeeded = {
+      name: "build",
+      status: "completed" as const,
+      conclusion: "success" as const,
+    };
+
+    beforeEach(() => {
+      actionGetConfigMock.mockReturnValue(jobsCfg);
+      apiFetchWorkflowRunActiveJobUrlRetry.mockResolvedValue({
+        success: true,
+        value: "test-url",
+      });
+    });
+
+    it("should await the named jobs rather than the run", async () => {
+      awaitRemoteRunGetWorkflowRunJobsResult.mockResolvedValue({
+        success: true,
+        value: [succeeded],
+      });
+
+      await main();
+
+      // Behaviour
+      expect(awaitRemoteRunGetWorkflowRunJobsResult).toHaveBeenCalledOnce();
+      expect(awaitRemoteRunGetWorkflowRunJobsResult).toHaveBeenCalledWith({
+        startTime: Date.now(),
+        pollIntervalMs: jobsCfg.pollIntervalMs,
+        runId: jobsCfg.runId,
+        runTimeoutMs: jobsCfg.runTimeoutSeconds * 1000,
+        cancelTimeoutMs: undefined,
+        jobs: ["build"],
+      });
+      expect(awaitRemoteRunGetWorkflowRunResult).not.toHaveBeenCalled();
+
+      // Result
+      expect(coreSetFailedMock).not.toHaveBeenCalled();
+      expect(awaitRemoteRunHandleActionFail).not.toHaveBeenCalled();
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+      expect(coreInfoLogMock).toHaveBeenCalledTimes(2);
+      expect(coreInfoLogMock.mock.calls[0]?.[0]).toMatchInlineSnapshot(`
+        "Awaiting completion of Jobs [build] in Workflow Run 123456...
+          ID: 123456
+          URL: test-url"
+      `);
+      expect(coreInfoLogMock.mock.calls[1]?.[0]).toMatchInlineSnapshot(`
+        "Awaited Jobs Completed:
+          Run ID: 123456
+          Jobs: [build]"
+      `);
+    });
+
+    it("should fail when a named job concludes unsuccessfully", async () => {
+      awaitRemoteRunGetWorkflowRunJobsResult.mockResolvedValue({
+        success: false,
+        reason: "inconclusive",
+        value: [{ ...succeeded, conclusion: "failure" }],
+      });
+
+      await main();
+
+      // Behaviour
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledOnce();
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledWith(
+        "Awaited Jobs have concluded unsuccessfully: build (failure)",
+        jobsCfg.runId,
+      );
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+    });
+
+    it("should fail when the run concludes without a named job", async () => {
+      awaitRemoteRunGetWorkflowRunJobsResult.mockResolvedValue({
+        success: false,
+        reason: "missing",
+        value: { missing: ["build"], observed: ["biuld"] },
+      });
+
+      await main();
+
+      // Behaviour
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledOnce();
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledWith(
+        "Run concluded without the awaited Jobs completing: build",
+        jobsCfg.runId,
+      );
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+    });
+
+    it("should fail on a timeout", async () => {
+      awaitRemoteRunGetWorkflowRunJobsResult.mockResolvedValue({
+        success: false,
+        reason: "timeout",
+      });
+
+      await main();
+
+      // Behaviour
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledOnce();
+      expect(awaitRemoteRunHandleActionFail).toHaveBeenCalledWith(
+        "Timeout exceeded while attempting to await the Jobs concluding (0ms)",
+        jobsCfg.runId,
+      );
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+    });
+
+    it("should pass the cancel timeout through when configured", async () => {
+      actionGetConfigMock.mockReturnValue({
+        ...jobsCfg,
+        cancelTimeoutSeconds: 120,
+      });
+      awaitRemoteRunGetWorkflowRunJobsResult.mockResolvedValue({
+        success: true,
+        value: [succeeded],
+      });
+
+      await main();
+
+      // Behaviour
+      expect(awaitRemoteRunGetWorkflowRunJobsResult).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelTimeoutMs: 120_000 }),
+      );
+
+      // Logging
+      assertOnlyCalled(coreInfoLogMock);
+    });
   });
 
   it("should warn and continue if the active job URL fetch times out", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,55 @@ import * as core from "@actions/core";
 
 import { getConfig } from "./action.ts";
 import * as api from "./api.ts";
-import { getWorkflowRunResult, handleActionFail } from "./await-remote-run.ts";
+import {
+  getWorkflowRunJobsResult,
+  getWorkflowRunResult,
+  handleActionFail,
+  type JobsResult,
+} from "./await-remote-run.ts";
 import * as constants from "./constants.ts";
 import { WorkflowRunConclusion } from "./types.ts";
+
+/**
+ * Report the awaited Jobs, failing the action unless every one succeeded.
+ */
+async function handleJobsResult(
+  result: JobsResult,
+  runId: number,
+  startTime: number,
+): Promise<void> {
+  if (result.success) {
+    const names = result.value.map((job) => job.name);
+    core.info(
+      "Awaited Jobs Completed:\n" +
+        `  Run ID: ${runId}\n` +
+        `  Jobs: [${names.join(", ")}]`,
+    );
+    return;
+  }
+
+  let failureMsg: string;
+  switch (result.reason) {
+    case "timeout": {
+      const elapsedTime = Date.now() - startTime;
+      failureMsg = `Timeout exceeded while attempting to await the Jobs concluding (${elapsedTime}ms)`;
+      break;
+    }
+    case "inconclusive": {
+      const failed = result.value
+        .map((job) => `${job.name} (${String(job.conclusion)})`)
+        .join(", ");
+      failureMsg = `Awaited Jobs have concluded unsuccessfully: ${failed}`;
+      break;
+    }
+    case "missing": {
+      failureMsg = `Run concluded without the awaited Jobs completing: ${result.value.missing.join(", ")}`;
+      break;
+    }
+  }
+
+  await handleActionFail(failureMsg, runId);
+}
 
 export async function main(): Promise<void> {
   try {
@@ -26,14 +72,17 @@ export async function main(): Promise<void> {
       );
     }
     const runUrl = `https://github.com/${config.owner}/${config.repo}/actions/runs/${config.runId}`;
+    const awaiting =
+      config.jobs === undefined
+        ? `Workflow Run ${config.runId}`
+        : `Jobs [${config.jobs.join(", ")}] in Workflow Run ${config.runId}`;
     core.info(
-      `Awaiting completion of Workflow Run ${config.runId}...\n` +
+      `Awaiting completion of ${awaiting}...\n` +
         `  ID: ${config.runId}\n` +
         `  URL: ${activeJobUrlResult.success ? activeJobUrlResult.value : runUrl}`,
     );
 
-    // Await the result
-    const runResult = await getWorkflowRunResult({
+    const runOpts = {
       startTime,
       pollIntervalMs: config.pollIntervalMs,
       runId: config.runId,
@@ -42,7 +91,19 @@ export async function main(): Promise<void> {
         config.cancelTimeoutSeconds === undefined
           ? undefined
           : config.cancelTimeoutSeconds * 1000,
-    });
+    };
+
+    if (config.jobs !== undefined) {
+      const jobsResult = await getWorkflowRunJobsResult({
+        ...runOpts,
+        jobs: config.jobs,
+      });
+      await handleJobsResult(jobsResult, config.runId, startTime);
+      return;
+    }
+
+    // Await the result
+    const runResult = await getWorkflowRunResult(runOpts);
     if (!runResult.success) {
       const elapsedTime = Date.now() - startTime;
       const failureMsg =

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,17 @@ export type WorkflowRunResult = Result<{
   conclusion: WorkflowRunConclusion;
 }>;
 
+/**
+ * Whether a poll settled on a result, kept apart from the result itself so an
+ * absent or falsy `T` cannot read as unsettled.
+ */
+export type PollAttempt<T> = { done: true; value: T } | { done: false };
+
+/**
+ * Not settled, so polling continues.
+ */
+export const POLL_PENDING: PollAttempt<never> = { done: false };
+
 export type WorkflowRunStatusResult =
   | ResultSuccess<WorkflowRunStatus.Completed>
   | ResultStatusPending

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,32 @@ export type WorkflowRunResult = Result<{
 }>;
 
 /**
+ * The outcome of awaiting named Jobs, generic over the Job shape so this stays
+ * independent of the API layer.
+ */
+export type WorkflowRunJobsResult<TJob> =
+  | ResultSuccess<TJob[]>
+  | RequestTimeout
+  | ResultJobsInconclusive<TJob>
+  | ResultJobsMissing;
+
+interface ResultJobsInconclusive<TJob> {
+  success: false;
+  reason: "inconclusive";
+  value: TJob[];
+}
+
+/**
+ * The run concluded without an awaited Job completing, so it never will.
+ * `observed` is every Job the run did produce, to place a name that never matched.
+ */
+interface ResultJobsMissing {
+  success: false;
+  reason: "missing";
+  value: { missing: string[]; observed: string[] };
+}
+
+/**
  * Whether a poll settled on a result, kept apart from the result itself so an
  * absent or falsy `T` cannot read as unsettled.
  */


### PR DESCRIPTION
Resolves #212



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for awaiting specific workflow jobs instead of the entire workflow run.
  * Accepts newline-separated job names, including matrix-expanded names.
  * Reports successful, failed, missing, and timed-out jobs with clear status messages.
  * Supports cancellation after awaited jobs fail.

* **Documentation**
  * Added configuration guidance covering job matching, matrix jobs, reusable workflows, cancellation, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->